### PR TITLE
Http headers

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -48,12 +48,15 @@ public class Myapp {
   public static void main(String[] args) {
     Client client = new Client();
     client.setAccessToken("YOUR-ACCESS-TOKEN");
+    client.setUserAgent("your-user-agent");
     WhoamiResponse response = client.identity.whoami();
     Account account = response.getData().getAccount();
     System.out.println("Account: " + account);
   }
 }
 ```
+
+The user agent value will be prepended to additional user-agent information that is set by default in this library. While it is not strictly necessary to set the user agent, it is often helpful for the team at DNSimple when debugging, so please consider setting it.
 
 ## Sandbox Usage
 

--- a/README.markdown
+++ b/README.markdown
@@ -47,6 +47,7 @@ import com.dnsimple.response.WhoamiResponse;
 public class Myapp {
   public static void main(String[] args) {
     Client client = new Client();
+    client.setAccessToken("YOUR-ACCESS-TOKEN");
     WhoamiResponse response = client.identity.whoami();
     Account account = response.getData().getAccount();
     System.out.println("Account: " + account);
@@ -68,6 +69,7 @@ public class Myapp {
   public static void main(String[] args) {
     Dnsimple.setBaseUrl("https://api.sandbox.dnsimple.com");
     Client client = new Client();
+    client.setAccessToken("YOUR-ACCESS-TOKEN");
     // ...
   }
 }

--- a/src/main/java/com/dnsimple/Client.java
+++ b/src/main/java/com/dnsimple/Client.java
@@ -111,4 +111,13 @@ public class Client {
     this.endpointClient.setTransport(transport);
   }
 
+  /**
+   * Set the access token to use for the client instance.
+   *
+   * @param accessToken The access token string
+   */
+  public void setAccessToken(String accessToken) {
+    this.endpointClient.setAccessToken(accessToken);
+  }
+
 }

--- a/src/main/java/com/dnsimple/Client.java
+++ b/src/main/java/com/dnsimple/Client.java
@@ -120,4 +120,13 @@ public class Client {
     this.endpointClient.setAccessToken(accessToken);
   }
 
+    /**
+   * Set the user agent to use for the client instance.
+   *
+   * @param userAgent The user agent string
+   */
+  public void setUserAgent(String userAgent) {
+    this.endpointClient.setUserAgent(userAgent);
+  }
+
 }

--- a/src/main/java/com/dnsimple/endpoints/http/AccountsEndpoint.java
+++ b/src/main/java/com/dnsimple/endpoints/http/AccountsEndpoint.java
@@ -17,7 +17,7 @@ public class AccountsEndpoint implements Accounts {
   }
 
   public ListAccountsResponse listAccounts() throws DnsimpleException, IOException {
-    HttpResponse response = client.get("/accounts");
+    HttpResponse response = client.get("accounts");
     return (ListAccountsResponse)client.parseResponse(response, ListAccountsResponse.class);
   }
 }

--- a/src/main/java/com/dnsimple/endpoints/http/HttpEndpointClient.java
+++ b/src/main/java/com/dnsimple/endpoints/http/HttpEndpointClient.java
@@ -9,6 +9,7 @@ import com.google.api.client.http.GenericUrl;
 import com.google.api.client.http.HttpRequest;
 import com.google.api.client.http.HttpResponse;
 import com.google.api.client.http.HttpContent;
+import com.google.api.client.http.HttpHeaders;
 import com.google.api.client.http.HttpMethods;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.http.HttpResponseException;
@@ -102,6 +103,9 @@ public class HttpEndpointClient {
     }
 
     HttpRequest request = transport.createRequestFactory().buildRequest(method, buildUrl(url, options), content);
+
+    HttpHeaders headers = request.getHeaders();
+    headers.setContentType("application/json");
 
     try {
       return request.execute();

--- a/src/main/java/com/dnsimple/endpoints/http/HttpEndpointClient.java
+++ b/src/main/java/com/dnsimple/endpoints/http/HttpEndpointClient.java
@@ -105,7 +105,10 @@ public class HttpEndpointClient {
     HttpRequest request = transport.createRequestFactory().buildRequest(method, buildUrl(url, options), content);
 
     HttpHeaders headers = request.getHeaders();
-    headers.setContentType("application/json");
+
+    if (data != null) {
+      headers.setContentType("application/json");
+    }
 
     try {
       return request.execute();

--- a/src/main/java/com/dnsimple/endpoints/http/HttpEndpointClient.java
+++ b/src/main/java/com/dnsimple/endpoints/http/HttpEndpointClient.java
@@ -30,6 +30,7 @@ public class HttpEndpointClient {
   private static final String API_VERSION_PATH = "/v2/";
 
   private HttpTransport transport;
+  private String accessToken;
 
   public HttpEndpointClient() {
     this.transport = new NetHttpTransport();
@@ -44,6 +45,15 @@ public class HttpEndpointClient {
    */
   public void setTransport(HttpTransport transport) {
     this.transport = transport;
+  }
+
+  /**
+   * Set the access token to use for the client instance.
+   *
+   * @param accessToken The access token string
+   */
+  public void setAccessToken(String accessToken) {
+    this.accessToken = accessToken;
   }
 
   protected HttpResponse get(String path) throws DnsimpleException, IOException {
@@ -78,14 +88,13 @@ public class HttpEndpointClient {
     return request(HttpMethods.PUT, versionedPath(path), attributes, null);
   }
 
-   protected HttpResponse patch(String path, Object attributes) throws DnsimpleException, IOException {
+  protected HttpResponse patch(String path, Object attributes) throws DnsimpleException, IOException {
     return patch(path, attributes, null);
   }
 
   protected HttpResponse patch(String path, Object attributes, Map<String, Object> options) throws DnsimpleException, IOException {
     return request(HttpMethods.PATCH, versionedPath(path), attributes, null);
   }
- 
 
   protected HttpResponse delete(String path) throws DnsimpleException, IOException {
     return delete(path, null);
@@ -106,6 +115,9 @@ public class HttpEndpointClient {
 
     HttpHeaders headers = request.getHeaders();
     headers.setAccept("application/json");
+    headers.setUserAgent("dnsimple-java/0.2.0");
+
+    headers.setAuthorization("Bearer " + accessToken);
 
     if (data != null) {
       headers.setContentType("application/json");

--- a/src/main/java/com/dnsimple/endpoints/http/HttpEndpointClient.java
+++ b/src/main/java/com/dnsimple/endpoints/http/HttpEndpointClient.java
@@ -23,14 +23,19 @@ import io.mikael.urlbuilder.UrlBuilder;
 import java.io.InputStream;
 import java.io.IOException;
 import java.util.Collections;
+import java.util.ArrayList;
 import java.util.Map;
 
 public class HttpEndpointClient {
 
+  public static final String DEFAULT_USER_AGENT = "dnsimple-java/0.2.0";
+
   private static final String API_VERSION_PATH = "/v2/";
+  private static final String MIME_APPLICATION_JSON = "application/json";
 
   private HttpTransport transport;
   private String accessToken;
+  private String userAgent;
 
   public HttpEndpointClient() {
     this.transport = new NetHttpTransport();
@@ -55,6 +60,16 @@ public class HttpEndpointClient {
   public void setAccessToken(String accessToken) {
     this.accessToken = accessToken;
   }
+
+  /**
+   * Set the user agent to use for the client instance.
+   *
+   * @param userAgent The user agent string
+   */
+  public void setUserAgent(String userAgent) {
+    this.userAgent = userAgent;
+  }
+
 
   protected HttpResponse get(String path) throws DnsimpleException, IOException {
     return get(path, null);
@@ -114,13 +129,21 @@ public class HttpEndpointClient {
     HttpRequest request = transport.createRequestFactory().buildRequest(method, buildUrl(url, options), content);
 
     HttpHeaders headers = request.getHeaders();
-    headers.setAccept("application/json");
-    headers.setUserAgent("dnsimple-java/0.2.0");
+    headers.setAccept(MIME_APPLICATION_JSON);
 
+    // Add the user agent string to the headers
+    ArrayList<String> fullUserAgent = new ArrayList<String>();
+    if (userAgent != null) {
+      fullUserAgent.add(userAgent);
+    }
+    fullUserAgent.add(DEFAULT_USER_AGENT);
+    headers.setUserAgent(String.join(" ", fullUserAgent));
+
+    // Add the authorization to the headers
     headers.setAuthorization("Bearer " + accessToken);
 
     if (data != null) {
-      headers.setContentType("application/json");
+      headers.setContentType(MIME_APPLICATION_JSON);
     }
 
     try {

--- a/src/main/java/com/dnsimple/endpoints/http/HttpEndpointClient.java
+++ b/src/main/java/com/dnsimple/endpoints/http/HttpEndpointClient.java
@@ -105,6 +105,7 @@ public class HttpEndpointClient {
     HttpRequest request = transport.createRequestFactory().buildRequest(method, buildUrl(url, options), content);
 
     HttpHeaders headers = request.getHeaders();
+    headers.setAccept("application/json");
 
     if (data != null) {
       headers.setContentType("application/json");

--- a/src/test/java/com/dnsimple/AccountsTest.java
+++ b/src/test/java/com/dnsimple/AccountsTest.java
@@ -20,10 +20,7 @@ public class AccountsTest extends DnsimpleTestBase {
 
   @Test
   public void testListAccounts() throws DnsimpleException, IOException {
-    HttpHeaders headers = getDefaultHeaders();
-    headers.setAuthorization("Bearer " + TEST_ACCESS_TOKEN);
-
-    Client client = mockAndExpectClient("https://api.dnsimple.com/v2/accounts", HttpMethods.GET, headers, null, resource("listAccounts/success.http"));
+    Client client = mockAndExpectClient("https://api.dnsimple.com/v2/accounts", HttpMethods.GET, resource("listAccounts/success.http"));
 
     ListAccountsResponse response = client.accounts.listAccounts();
 

--- a/src/test/java/com/dnsimple/AccountsTest.java
+++ b/src/test/java/com/dnsimple/AccountsTest.java
@@ -20,8 +20,8 @@ public class AccountsTest extends DnsimpleTestBase {
 
   @Test
   public void testListAccounts() throws DnsimpleException, IOException {
-    HttpHeaders headers = new HttpHeaders();
-    headers.setAccept("application/json");
+    HttpHeaders headers = getDefaultHeaders();
+    headers.setAuthorization("Bearer " + TEST_ACCESS_TOKEN);
 
     Client client = mockAndExpectClient("https://api.dnsimple.com/v2/accounts", HttpMethods.GET, headers, null, resource("listAccounts/success.http"));
 

--- a/src/test/java/com/dnsimple/AccountsTest.java
+++ b/src/test/java/com/dnsimple/AccountsTest.java
@@ -11,13 +11,19 @@ import junit.framework.Assert;
 
 import org.junit.Test;
 
+import com.google.api.client.http.HttpHeaders;
+import com.google.api.client.http.HttpMethods;
+
 import static org.junit.Assert.assertEquals;
 
 public class AccountsTest extends DnsimpleTestBase {
 
   @Test
   public void testListAccounts() throws DnsimpleException, IOException {
-    Client client = mockClient(resource("listAccounts/success.http"));
+    HttpHeaders headers = new HttpHeaders();
+    headers.setAccept("application/json");
+
+    Client client = mockAndExpectClient("https://api.dnsimple.com/v2/accounts", HttpMethods.GET, headers, null, resource("listAccounts/success.http"));
 
     ListAccountsResponse response = client.accounts.listAccounts();
 

--- a/src/test/java/com/dnsimple/ClientTest.java
+++ b/src/test/java/com/dnsimple/ClientTest.java
@@ -1,14 +1,40 @@
 package com.dnsimple;
 
+import com.dnsimple.exception.DnsimpleException;
+
 import junit.framework.Assert;
 
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 
-public class ClientTest {
+import com.google.api.client.http.HttpHeaders;
+import com.google.api.client.http.HttpMethods;
+
+import java.io.IOException;
+
+public class ClientTest extends DnsimpleTestBase {
   @Test
   public void testNewClient() {
     Client client = new Client();
+  }
+
+  @Test
+  public void testAuthorizationHeader() throws DnsimpleException, IOException {
+    HttpHeaders headers = getDefaultHeaders();
+    headers.setAuthorization("Bearer " + TEST_ACCESS_TOKEN);
+
+    Client client = mockAndExpectClient("https://api.dnsimple.com/v2/accounts", HttpMethods.GET, headers, null, resource("listAccounts/success.http"));
+    client.accounts.listAccounts();
+  }
+
+  @Test
+  public void testUserAgentHeader() throws DnsimpleException, IOException {
+    HttpHeaders headers = getDefaultHeaders();
+    headers.setUserAgent("my-user-agent dnsimple-java/0.2.0 Google-HTTP-Java-Client/1.20.0 (gzip)");
+
+    Client client = mockAndExpectClient("https://api.dnsimple.com/v2/accounts", HttpMethods.GET, headers, null, resource("listAccounts/success.http"));
+    client.setUserAgent("my-user-agent");
+    client.accounts.listAccounts();
   }
 }

--- a/src/test/java/com/dnsimple/ContactsTest.java
+++ b/src/test/java/com/dnsimple/ContactsTest.java
@@ -128,7 +128,7 @@ public class ContactsTest extends DnsimpleTestBase {
     attributes.put("first_name", "John");
     attributes.put("last_name", "Smith");
 
-    Client client = expectClient("https://api.dnsimple.com/v2/1010/contacts", HttpMethods.POST, attributes);
+    Client client = expectClient("https://api.dnsimple.com/v2/1010/contacts", HttpMethods.POST, new HashMap<String, Object>(), attributes);
 
     client.contacts.createContact(accountId, attributes);
   }

--- a/src/test/java/com/dnsimple/ContactsTest.java
+++ b/src/test/java/com/dnsimple/ContactsTest.java
@@ -18,6 +18,7 @@ import org.junit.Test;
 
 import static org.junit.Assert.*;
 
+import com.google.api.client.http.HttpHeaders;
 import com.google.api.client.http.HttpMethods;
 import com.google.api.client.util.Data;
 
@@ -83,7 +84,7 @@ public class ContactsTest extends DnsimpleTestBase {
 
   @Test
   public void testGetContact() throws DnsimpleException, IOException {
-    Client client = mockAndExpectClient("https://api.dnsimple.com/v2/1010/contacts/1", HttpMethods.GET, null, resource("getContact/success.http"));
+    Client client = mockAndExpectClient("https://api.dnsimple.com/v2/1010/contacts/1", HttpMethods.GET, new HttpHeaders(), null, resource("getContact/success.http"));
 
     String accountId = "1010";
     String contactId = "1";
@@ -128,7 +129,7 @@ public class ContactsTest extends DnsimpleTestBase {
     attributes.put("first_name", "John");
     attributes.put("last_name", "Smith");
 
-    Client client = expectClient("https://api.dnsimple.com/v2/1010/contacts", HttpMethods.POST, new HashMap<String, Object>(), attributes);
+    Client client = expectClient("https://api.dnsimple.com/v2/1010/contacts", HttpMethods.POST, new HttpHeaders(), attributes);
 
     client.contacts.createContact(accountId, attributes);
   }
@@ -155,7 +156,7 @@ public class ContactsTest extends DnsimpleTestBase {
     attributes.put("first_name", "John");
     attributes.put("last_name", "Smith");
 
-    Client client = mockAndExpectClient("https://api.dnsimple.com/v2/1010/contacts/1", HttpMethods.PATCH, attributes, resource("updateContact/success.http"));
+    Client client = mockAndExpectClient("https://api.dnsimple.com/v2/1010/contacts/1", HttpMethods.PATCH, new HttpHeaders(), attributes, resource("updateContact/success.http"));
 
     UpdateContactResponse response = client.contacts.updateContact(accountId, contactId, attributes);
     Contact contact = response.getData();

--- a/src/test/java/com/dnsimple/DnsimpleTestBase.java
+++ b/src/test/java/com/dnsimple/DnsimpleTestBase.java
@@ -3,8 +3,9 @@ package com.dnsimple;
 import static org.junit.Assert.assertEquals;
 
 import com.google.api.client.http.GenericUrl;
-import com.google.api.client.http.HttpTransport;
+import com.google.api.client.http.HttpHeaders;
 import com.google.api.client.http.HttpMethods;
+import com.google.api.client.http.HttpTransport;
 import com.google.api.client.http.LowLevelHttpRequest;
 import com.google.api.client.http.LowLevelHttpResponse;
 import com.google.api.client.json.Json;
@@ -75,18 +76,19 @@ public abstract class DnsimpleTestBase {
    * @return The Client instance
    */
   public Client expectClient(final String expectedUrl, final String expectedMethod) {
-    return expectClient(expectedUrl, expectedMethod, new Object());
+    return expectClient(expectedUrl, expectedMethod, new HashMap<String, Object>(), new Object());
   }
 
   /**
-   * Return a Client that is configured to expect a specific URL, HTTP method, and request attributes.
+   * Return a Client that is configured to expect a specific URL, HTTP method, request attributes, and HTTP headers.
    *
    * @param expectedUrl The URL string that is expected
    * @param expectedMethod The HTTP method String that is expected
+   * @param expectedHeaders a Map<String, Object> of headers
    * @param expectedAttributes A map of values as attributes
    * @return The Client instance
    */
-  public Client expectClient(final String expectedUrl, final String expectedMethod, final Object expectedAttributes) {
+  public Client expectClient(final String expectedUrl, final String expectedMethod, final Map<String, Object> expectedHeaders, final Object expectedAttributes) {
     Client client = new Client();
 
     HttpTransport transport = new MockHttpTransport() {
@@ -102,6 +104,10 @@ public abstract class DnsimpleTestBase {
               JsonParser jsonParser = GsonFactory.getDefaultInstance().createJsonParser(getContentAsString());
               Map<String,Object> attributes = jsonParser.parse(GenericJson.class);
               assertEquals(expectedAttributes, attributes);
+            }
+
+            for (Map.Entry<String, Object> expectedHeader : expectedHeaders.entrySet()) {
+              assertEquals(expectedHeader.getValue(), getHeaders().get(expectedHeader.getKey()));
             }
 
             MockLowLevelHttpResponse response = new MockLowLevelHttpResponse();

--- a/src/test/java/com/dnsimple/DnsimpleTestBase.java
+++ b/src/test/java/com/dnsimple/DnsimpleTestBase.java
@@ -132,7 +132,7 @@ public abstract class DnsimpleTestBase {
    * @return The Client instance
    */
   public Client mockAndExpectClient(final String expectedUrl, final String expectedMethod, final String httpResponse) {
-    return mockAndExpectClient(expectedUrl, expectedMethod, new Object(), httpResponse);
+    return mockAndExpectClient(expectedUrl, expectedMethod, new HashMap<String, Object>(), new Object(), httpResponse);
   }
 
   /**
@@ -141,11 +141,12 @@ public abstract class DnsimpleTestBase {
    *
    * @param expectedUrl The URL string that is expected
    * @param expectedMethod The HTTP method String that is expected
+   * @param expectedHeaders A Map<String, Object> of expected headers
    * @param expectedAttributes A map of values as attributes
    * @param httpResponse The full HTTP response data
    * @return The Client instance
    */
-  public Client mockAndExpectClient(final String expectedUrl, final String expectedMethod, final Object expectedAttributes, final String httpResponse) {
+  public Client mockAndExpectClient(final String expectedUrl, final String expectedMethod, final Map<String, Object> expectedHeaders, final Object expectedAttributes, final String httpResponse) {
     Client client = new Client();
 
     HttpTransport transport = new MockHttpTransport() {
@@ -166,6 +167,10 @@ public abstract class DnsimpleTestBase {
                 Object attributes = jsonParser.parse(GenericJson.class);
                 assertEquals(expectedAttributes, attributes);
               }
+            }
+
+            for (Map.Entry<String, Object> expectedHeader : expectedHeaders.entrySet()) {
+              assertEquals(expectedHeader.getValue(), getHeaders().get(expectedHeader.getKey()));
             }
 
             MockLowLevelHttpResponse response = new MockLowLevelHttpResponse();

--- a/src/test/java/com/dnsimple/DnsimpleTestBase.java
+++ b/src/test/java/com/dnsimple/DnsimpleTestBase.java
@@ -31,6 +31,8 @@ import java.util.Collections;
  */
 public abstract class DnsimpleTestBase {
 
+  public static final String TEST_ACCESS_TOKEN = "test-access-token";
+
   /**
    * Return a Client that is mocked to return the given HTTP response.
    *
@@ -148,6 +150,7 @@ public abstract class DnsimpleTestBase {
    */
   public Client mockAndExpectClient(final String expectedUrl, final String expectedMethod, final Map<String, Object> expectedHeaders, final Object expectedAttributes, final String httpResponse) {
     Client client = new Client();
+    client.setAccessToken(TEST_ACCESS_TOKEN);
 
     HttpTransport transport = new MockHttpTransport() {
       @Override
@@ -206,7 +209,20 @@ public abstract class DnsimpleTestBase {
     }
 
     return out.toString("utf8");
+  }
 
+  /**
+   * Get the default HttpHeaders that should be expected on every request.
+   *
+   * You may set additional headers in the collection as necessary.
+   *
+   * @return The default HttpHeaders
+   */
+  public HttpHeaders getDefaultHeaders() {
+    HttpHeaders headers = new HttpHeaders();
+    headers.setAccept("application/json");
+    headers.setUserAgent("dnsimple-java/0.2.0 Google-HTTP-Java-Client/1.20.0 (gzip)");
+    return headers;
   }
 
   private MockLowLevelHttpResponse mockResponse(MockLowLevelHttpResponse response, String httpResponse) throws IOException {

--- a/src/test/java/com/dnsimple/DomainServicesTest.java
+++ b/src/test/java/com/dnsimple/DomainServicesTest.java
@@ -15,6 +15,7 @@ import org.junit.Test;
 
 import static org.junit.Assert.*;
 
+import com.google.api.client.http.HttpHeaders;
 import com.google.api.client.http.HttpMethods;
 import com.google.api.client.util.Data;
 
@@ -86,7 +87,7 @@ public class DomainServicesTest extends DnsimpleTestBase {
   public void testApplyService() throws DnsimpleException, IOException {
     HashMap<String, Object> settings = new HashMap<String, Object>();
 
-    Client client = mockAndExpectClient("https://api.dnsimple.com/v2/1010/domains/example.com/services/2", HttpMethods.POST, settings, resource("applyService/success.http"));
+    Client client = mockAndExpectClient("https://api.dnsimple.com/v2/1010/domains/example.com/services/2", HttpMethods.POST, new HttpHeaders(), settings, resource("applyService/success.http"));
 
     String accountId = "1010";
     String domainId = "example.com";
@@ -98,7 +99,7 @@ public class DomainServicesTest extends DnsimpleTestBase {
 
   @Test
   public void testUnapplyService() throws DnsimpleException, IOException {
-    Client client = mockAndExpectClient("https://api.dnsimple.com/v2/1010/domains/example.com/services/2", HttpMethods.DELETE, null, resource("unapplyService/success.http"));
+    Client client = mockAndExpectClient("https://api.dnsimple.com/v2/1010/domains/example.com/services/2", HttpMethods.DELETE, resource("unapplyService/success.http"));
 
     String accountId = "1010";
     String domainId = "example.com";

--- a/src/test/java/com/dnsimple/DomainsTest.java
+++ b/src/test/java/com/dnsimple/DomainsTest.java
@@ -127,7 +127,7 @@ public class DomainsTest extends DnsimpleTestBase {
     HashMap<String, Object> attributes = new HashMap<String, Object>();
     attributes.put("name", "example.com");
 
-    Client client = expectClient("https://api.dnsimple.com/v2/1010/domains", HttpMethods.POST, attributes);
+    Client client = expectClient("https://api.dnsimple.com/v2/1010/domains", HttpMethods.POST, new HashMap<String, Object>(), attributes);
 
     client.domains.createDomain(accountId, attributes);
   }

--- a/src/test/java/com/dnsimple/OauthTest.java
+++ b/src/test/java/com/dnsimple/OauthTest.java
@@ -10,6 +10,7 @@ import org.junit.Test;
 
 import static org.junit.Assert.*;
 
+import com.google.api.client.http.HttpHeaders;
 import com.google.api.client.http.HttpMethods;
 import com.google.api.client.util.Data;
 
@@ -30,7 +31,7 @@ public class OauthTest extends DnsimpleTestBase {
     attributes.put("client_secret", clientSecret);
     attributes.put("grant_type", "authorization_code");
 
-    Client client = mockAndExpectClient("https://api.dnsimple.com/v2/oauth/access_token", HttpMethods.POST, attributes, resource("oauthAccessToken/success.http"));
+    Client client = mockAndExpectClient("https://api.dnsimple.com/v2/oauth/access_token", HttpMethods.POST, new HttpHeaders(), attributes, resource("oauthAccessToken/success.http"));
 
     OauthToken token = client.oauth.exchangeAuthorizationForToken(code, clientId, clientSecret);
     assertEquals("zKQ7OLqF5N1gylcJweA9WodA000BUNJD", token.getAccessToken());
@@ -59,7 +60,7 @@ public class OauthTest extends DnsimpleTestBase {
     expectedAttributes.put("state", state);
     expectedAttributes.put("redirect_uri", redirectUri);
 
-    Client client = mockAndExpectClient("https://api.dnsimple.com/v2/oauth/access_token", HttpMethods.POST, expectedAttributes, resource("oauthAccessToken/success.http"));
+    Client client = mockAndExpectClient("https://api.dnsimple.com/v2/oauth/access_token", HttpMethods.POST, new HttpHeaders(), expectedAttributes, resource("oauthAccessToken/success.http"));
 
     OauthToken token = client.oauth.exchangeAuthorizationForToken(code, clientId, clientSecret, options);
     assertEquals("zKQ7OLqF5N1gylcJweA9WodA000BUNJD", token.getAccessToken());

--- a/src/test/java/com/dnsimple/RegistrarAutoRenewTest.java
+++ b/src/test/java/com/dnsimple/RegistrarAutoRenewTest.java
@@ -11,6 +11,7 @@ import org.junit.Test;
 
 import static org.junit.Assert.*;
 
+import com.google.api.client.http.HttpHeaders;
 import com.google.api.client.http.HttpMethods;
 
 import java.io.IOException;
@@ -22,7 +23,7 @@ public class RegistrarAutoRenewTest extends DnsimpleTestBase {
     String accountId = "1010";
     String domainId = "example.com";
 
-    Client client = mockAndExpectClient("https://api.dnsimple.com/v2/1010/registrar/domains/example.com/auto_renewal", HttpMethods.PUT, null, resource("enableAutoRenewal/success.http"));
+    Client client = mockAndExpectClient("https://api.dnsimple.com/v2/1010/registrar/domains/example.com/auto_renewal", HttpMethods.PUT, new HttpHeaders(), null, resource("enableAutoRenewal/success.http"));
 
     EnableAutoRenewalResponse response = client.registrar.enableAutoRenewal(accountId, domainId);
     assertEquals(null, response.getData());
@@ -33,7 +34,7 @@ public class RegistrarAutoRenewTest extends DnsimpleTestBase {
     String accountId = "1010";
     String domainId = "0";
 
-    Client client = mockAndExpectClient("https://api.dnsimple.com/v2/1010/registrar/domains/0/auto_renewal", HttpMethods.PUT, null, resource("notfound-domain.http"));
+    Client client = mockAndExpectClient("https://api.dnsimple.com/v2/1010/registrar/domains/0/auto_renewal", HttpMethods.PUT, new HttpHeaders(), null, resource("notfound-domain.http"));
 
     client.registrar.enableAutoRenewal(accountId, domainId);
   }
@@ -43,7 +44,7 @@ public class RegistrarAutoRenewTest extends DnsimpleTestBase {
     String accountId = "1010";
     String domainId = "example.com";
 
-    Client client = mockAndExpectClient("https://api.dnsimple.com/v2/1010/registrar/domains/example.com/auto_renewal", HttpMethods.DELETE, null, resource("disableAutoRenewal/success.http"));
+    Client client = mockAndExpectClient("https://api.dnsimple.com/v2/1010/registrar/domains/example.com/auto_renewal", HttpMethods.DELETE, new HttpHeaders(), null, resource("disableAutoRenewal/success.http"));
 
     DisableAutoRenewalResponse response = client.registrar.disableAutoRenewal(accountId, domainId);
     assertEquals(null, response.getData());
@@ -54,7 +55,7 @@ public class RegistrarAutoRenewTest extends DnsimpleTestBase {
     String accountId = "1010";
     String domainId = "0";
 
-    Client client = mockAndExpectClient("https://api.dnsimple.com/v2/1010/registrar/domains/0/auto_renewal", HttpMethods.DELETE, null, resource("notfound-domain.http"));
+    Client client = mockAndExpectClient("https://api.dnsimple.com/v2/1010/registrar/domains/0/auto_renewal", HttpMethods.DELETE, new HttpHeaders(), null, resource("notfound-domain.http"));
 
     client.registrar.disableAutoRenewal(accountId, domainId);
   }

--- a/src/test/java/com/dnsimple/RegistrarDelegationTest.java
+++ b/src/test/java/com/dnsimple/RegistrarDelegationTest.java
@@ -15,6 +15,7 @@ import org.junit.Test;
 
 import static org.junit.Assert.*;
 
+import com.google.api.client.http.HttpHeaders;
 import com.google.api.client.http.HttpMethods;
 import com.google.api.client.util.Data;
 
@@ -29,7 +30,7 @@ public class RegistrarDelegationTest extends DnsimpleTestBase {
     String accountId = "1010";
     String domainId = "example.com";
 
-    Client client = mockAndExpectClient("https://api.dnsimple.com/v2/1010/registrar/domains/example.com/delegation", HttpMethods.GET, null, resource("getDomainDelegation/success.http"));
+    Client client = mockAndExpectClient("https://api.dnsimple.com/v2/1010/registrar/domains/example.com/delegation", HttpMethods.GET, resource("getDomainDelegation/success.http"));
 
     GetDomainDelegationResponse response = client.registrar.getDomainDelegation(accountId, domainId);
     List<String> delegatedTo = response.getData();
@@ -48,7 +49,7 @@ public class RegistrarDelegationTest extends DnsimpleTestBase {
     List<String> nameServerNames = new ArrayList<String>();
     nameServerNames.add("ns1.example.com");
 
-    Client client = mockAndExpectClient("https://api.dnsimple.com/v2/1010/registrar/domains/example.com/delegation", HttpMethods.PUT, nameServerNames, resource("changeDomainDelegation/success.http"));
+    Client client = mockAndExpectClient("https://api.dnsimple.com/v2/1010/registrar/domains/example.com/delegation", HttpMethods.PUT, new HttpHeaders(), nameServerNames, resource("changeDomainDelegation/success.http"));
 
     ChangeDomainDelegationResponse response = client.registrar.changeDomainDelegation(accountId, domainId, nameServerNames);
     List<String> delegatedTo = response.getData();
@@ -66,7 +67,7 @@ public class RegistrarDelegationTest extends DnsimpleTestBase {
     nameServerNames.add("ns1.example.com");
     nameServerNames.add("ns2.example.com");
 
-    Client client = mockAndExpectClient("https://api.dnsimple.com/v2/1010/registrar/domains/example.com/delegation/vanity", HttpMethods.PUT, nameServerNames, resource("changeDomainDelegationToVanity/success.http"));
+    Client client = mockAndExpectClient("https://api.dnsimple.com/v2/1010/registrar/domains/example.com/delegation/vanity", HttpMethods.PUT, new HttpHeaders(), nameServerNames, resource("changeDomainDelegationToVanity/success.http"));
 
     ChangeDomainDelegationToVanityResponse response = client.registrar.changeDomainDelegationToVanity(accountId, domainId, nameServerNames);
     List<NameServer> delegatedTo = response.getData();
@@ -85,7 +86,7 @@ public class RegistrarDelegationTest extends DnsimpleTestBase {
     String accountId = "1010";
     String domainId = "example.com";
 
-    Client client = mockAndExpectClient("https://api.dnsimple.com/v2/1010/registrar/domains/example.com/delegation/vanity", HttpMethods.DELETE, null, resource("changeDomainDelegationFromVanity/success.http"));
+    Client client = mockAndExpectClient("https://api.dnsimple.com/v2/1010/registrar/domains/example.com/delegation/vanity", HttpMethods.DELETE, resource("changeDomainDelegationFromVanity/success.http"));
 
     ChangeDomainDelegationFromVanityResponse response = client.registrar.changeDomainDelegationFromVanity(accountId, domainId);
     assertEquals(null, response.getData());

--- a/src/test/java/com/dnsimple/RegistrarTest.java
+++ b/src/test/java/com/dnsimple/RegistrarTest.java
@@ -15,6 +15,7 @@ import org.junit.Test;
 
 import static org.junit.Assert.*;
 
+import com.google.api.client.http.HttpHeaders;
 import com.google.api.client.http.HttpMethods;
 
 import java.io.IOException;
@@ -27,7 +28,7 @@ public class RegistrarTest extends DnsimpleTestBase {
     String accountId = "1010";
     String name = "example.com";
 
-    Client client = mockAndExpectClient("https://api.dnsimple.com/v2/1010/registrar/domains/example.com/check", HttpMethods.GET, null, resource("checkDomain/success.http"));
+    Client client = mockAndExpectClient("https://api.dnsimple.com/v2/1010/registrar/domains/example.com/check", HttpMethods.GET, new HttpHeaders(), null, resource("checkDomain/success.http"));
 
     CheckDomainResponse response = client.registrar.checkDomain(accountId, name);
     DomainAvailability availability = response.getData();
@@ -43,7 +44,7 @@ public class RegistrarTest extends DnsimpleTestBase {
     HashMap<String, Object> attributes = new HashMap<String, Object>();
     attributes.put("registrant_id", "10");
 
-    Client client = mockAndExpectClient("https://api.dnsimple.com/v2/1010/registrar/domains/example.com/register", HttpMethods.POST, attributes, resource("registerDomain/success.http"));
+    Client client = mockAndExpectClient("https://api.dnsimple.com/v2/1010/registrar/domains/example.com/register", HttpMethods.POST, new HttpHeaders(), attributes, resource("registerDomain/success.http"));
 
     RegisterDomainResponse response = client.registrar.registerDomain(accountId, name, attributes);
     Domain domain = response.getData();
@@ -68,7 +69,7 @@ public class RegistrarTest extends DnsimpleTestBase {
     HashMap<String, Object> attributes = new HashMap<String, Object>();
     attributes.put("period", "3");
 
-    Client client = mockAndExpectClient("https://api.dnsimple.com/v2/1010/registrar/domains/example.com/renewal", HttpMethods.POST, attributes, resource("renewDomain/success.http"));
+    Client client = mockAndExpectClient("https://api.dnsimple.com/v2/1010/registrar/domains/example.com/renewal", HttpMethods.POST, new HttpHeaders(), attributes, resource("renewDomain/success.http"));
 
     RenewDomainResponse response = client.registrar.renewDomain(accountId, name, attributes);
     Domain domain = response.getData();
@@ -82,7 +83,7 @@ public class RegistrarTest extends DnsimpleTestBase {
     HashMap<String, Object> attributes = new HashMap<String, Object>();
     attributes.put("period", "3");
 
-    Client client = mockAndExpectClient("https://api.dnsimple.com/v2/1010/registrar/domains/example.com/renewal", HttpMethods.POST, attributes, resource("renewDomain/error-tooearly.http"));
+    Client client = mockAndExpectClient("https://api.dnsimple.com/v2/1010/registrar/domains/example.com/renewal", HttpMethods.POST, new HttpHeaders(), attributes, resource("renewDomain/error-tooearly.http"));
 
     client.registrar.renewDomain(accountId, name, attributes);
   }
@@ -95,7 +96,7 @@ public class RegistrarTest extends DnsimpleTestBase {
     attributes.put("registrant_id", "1");
     attributes.put("auth_info", "x1y2z3");
 
-    Client client = mockAndExpectClient("https://api.dnsimple.com/v2/1010/registrar/domains/example.com/transfer", HttpMethods.POST, attributes, resource("transferDomain/success.http"));
+    Client client = mockAndExpectClient("https://api.dnsimple.com/v2/1010/registrar/domains/example.com/transfer", HttpMethods.POST, new HttpHeaders(), attributes, resource("transferDomain/success.http"));
 
     TransferDomainResponse response = client.registrar.transferDomain(accountId, name, attributes);
     Domain domain = response.getData();
@@ -110,7 +111,7 @@ public class RegistrarTest extends DnsimpleTestBase {
     attributes.put("registrant_id", "1");
     attributes.put("auth_info", "x1y2z3");
 
-    Client client = mockAndExpectClient("https://api.dnsimple.com/v2/1010/registrar/domains/example.com/transfer", HttpMethods.POST, attributes, resource("transferDomain/error-isdnsimple.http"));
+    Client client = mockAndExpectClient("https://api.dnsimple.com/v2/1010/registrar/domains/example.com/transfer", HttpMethods.POST, new HttpHeaders(), attributes, resource("transferDomain/error-isdnsimple.http"));
 
     client.registrar.transferDomain(accountId, name, attributes);
   }
@@ -122,7 +123,7 @@ public class RegistrarTest extends DnsimpleTestBase {
     HashMap<String, Object> attributes = new HashMap<String, Object>();
     attributes.put("registrant_id", "1");
 
-    Client client = mockAndExpectClient("https://api.dnsimple.com/v2/1010/registrar/domains/example.com/transfer", HttpMethods.POST, attributes, resource("transferDomain/error-missing-authcode.http"));
+    Client client = mockAndExpectClient("https://api.dnsimple.com/v2/1010/registrar/domains/example.com/transfer", HttpMethods.POST, new HttpHeaders(), attributes, resource("transferDomain/error-missing-authcode.http"));
 
     client.registrar.transferDomain(accountId, name, attributes);
   }
@@ -132,7 +133,7 @@ public class RegistrarTest extends DnsimpleTestBase {
     String accountId = "1010";
     String name = "example.com";
 
-    Client client = mockAndExpectClient("https://api.dnsimple.com/v2/1010/registrar/domains/example.com/transfer_out", HttpMethods.POST, resource("transferDomainOut/success.http"));
+    Client client = mockAndExpectClient("https://api.dnsimple.com/v2/1010/registrar/domains/example.com/transfer_out", HttpMethods.POST, new HttpHeaders(), null, resource("transferDomainOut/success.http"));
 
     TransferDomainOutResponse response = client.registrar.transferDomainOut(accountId, name);
     assertEquals(null, response.getData());

--- a/src/test/java/com/dnsimple/RegistrarWhoisPrivacyTest.java
+++ b/src/test/java/com/dnsimple/RegistrarWhoisPrivacyTest.java
@@ -14,6 +14,7 @@ import org.junit.Test;
 
 import static org.junit.Assert.*;
 
+import com.google.api.client.http.HttpHeaders;
 import com.google.api.client.http.HttpMethods;
 import com.google.api.client.util.Data;
 
@@ -27,7 +28,7 @@ public class RegistrarWhoisPrivacyTest extends DnsimpleTestBase {
     String accountId = "1010";
     String domainId = "example.com";
 
-    Client client = mockAndExpectClient("https://api.dnsimple.com/v2/1010/registrar/domains/example.com/whois_privacy", HttpMethods.GET, null, resource("getWhoisPrivacy/success.http"));
+    Client client = mockAndExpectClient("https://api.dnsimple.com/v2/1010/registrar/domains/example.com/whois_privacy", HttpMethods.GET, new HttpHeaders(), null, resource("getWhoisPrivacy/success.http"));
 
     GetWhoisPrivacyResponse response = client.registrar.getWhoisPrivacy(accountId, domainId);
     WhoisPrivacy whoisPrivacy = response.getData();
@@ -44,7 +45,7 @@ public class RegistrarWhoisPrivacyTest extends DnsimpleTestBase {
     String accountId = "1010";
     String domainId = "example.com";
 
-    Client client = mockAndExpectClient("https://api.dnsimple.com/v2/1010/registrar/domains/example.com/whois_privacy", HttpMethods.PUT, null, resource("enableWhoisPrivacy/success.http"));
+    Client client = mockAndExpectClient("https://api.dnsimple.com/v2/1010/registrar/domains/example.com/whois_privacy", HttpMethods.PUT, new HttpHeaders(), null, resource("enableWhoisPrivacy/success.http"));
 
     EnableWhoisPrivacyResponse response = client.registrar.enableWhoisPrivacy(accountId, domainId);
   }
@@ -54,7 +55,7 @@ public class RegistrarWhoisPrivacyTest extends DnsimpleTestBase {
     String accountId = "1010";
     String domainId = "example.com";
 
-    Client client = mockAndExpectClient("https://api.dnsimple.com/v2/1010/registrar/domains/example.com/whois_privacy", HttpMethods.PUT, null, resource("enableWhoisPrivacy/created.http"));
+    Client client = mockAndExpectClient("https://api.dnsimple.com/v2/1010/registrar/domains/example.com/whois_privacy", HttpMethods.PUT, new HttpHeaders(), null, resource("enableWhoisPrivacy/created.http"));
 
     EnableWhoisPrivacyResponse response = client.registrar.enableWhoisPrivacy(accountId, domainId);
     WhoisPrivacy whoisPrivacy = response.getData();
@@ -66,7 +67,7 @@ public class RegistrarWhoisPrivacyTest extends DnsimpleTestBase {
     String accountId = "1010";
     String domainId = "example.com";
 
-    Client client = mockAndExpectClient("https://api.dnsimple.com/v2/1010/registrar/domains/example.com/whois_privacy", HttpMethods.DELETE, null, resource("disableWhoisPrivacy/success.http"));
+    Client client = mockAndExpectClient("https://api.dnsimple.com/v2/1010/registrar/domains/example.com/whois_privacy", HttpMethods.DELETE, new HttpHeaders(), null, resource("disableWhoisPrivacy/success.http"));
 
     DisableWhoisPrivacyResponse response = client.registrar.disableWhoisPrivacy(accountId, domainId);
     WhoisPrivacy whoisPrivacy = response.getData();

--- a/src/test/java/com/dnsimple/TemplateRecordsTest.java
+++ b/src/test/java/com/dnsimple/TemplateRecordsTest.java
@@ -15,6 +15,7 @@ import org.junit.Test;
 
 import static org.junit.Assert.*;
 
+import com.google.api.client.http.HttpHeaders;
 import com.google.api.client.http.HttpMethods;
 import com.google.api.client.util.Data;
 
@@ -89,7 +90,7 @@ public class TemplateRecordsTest extends DnsimpleTestBase {
 
   @Test
   public void testGetTemplateRecord() throws DnsimpleException, IOException {
-    Client client = mockAndExpectClient("https://api.dnsimple.com/v2/1010/templates/1/records/301", HttpMethods.GET, null, resource("getTemplateRecord/success.http"));
+    Client client = mockAndExpectClient("https://api.dnsimple.com/v2/1010/templates/1/records/301", HttpMethods.GET, resource("getTemplateRecord/success.http"));
 
     String accountId = "1010";
     String templateId = "1";

--- a/src/test/java/com/dnsimple/TemplateRecordsTest.java
+++ b/src/test/java/com/dnsimple/TemplateRecordsTest.java
@@ -117,7 +117,7 @@ public class TemplateRecordsTest extends DnsimpleTestBase {
     attributes.put("name", "www");
     attributes.put("content", "example.com");
 
-    Client client = expectClient("https://api.dnsimple.com/v2/1010/templates/1/records", HttpMethods.POST, attributes);
+    Client client = expectClient("https://api.dnsimple.com/v2/1010/templates/1/records", HttpMethods.POST, new HashMap<String, Object>(), attributes);
 
     client.templates.createTemplateRecord(accountId, templateId, attributes);
   }

--- a/src/test/java/com/dnsimple/TemplatesTest.java
+++ b/src/test/java/com/dnsimple/TemplatesTest.java
@@ -120,7 +120,7 @@ public class TemplatesTest extends DnsimpleTestBase {
     attributes.put("name", "A Template");
     attributes.put("short_name", "a_template");
 
-    Client client = expectClient("https://api.dnsimple.com/v2/1010/templates", HttpMethods.POST, attributes);
+    Client client = expectClient("https://api.dnsimple.com/v2/1010/templates", HttpMethods.POST, new HashMap<String, Object>(), attributes);
 
     client.templates.createTemplate(accountId, attributes);
   }

--- a/src/test/java/com/dnsimple/TemplatesTest.java
+++ b/src/test/java/com/dnsimple/TemplatesTest.java
@@ -17,6 +17,7 @@ import org.junit.Test;
 
 import static org.junit.Assert.*;
 
+import com.google.api.client.http.HttpHeaders;
 import com.google.api.client.http.HttpMethods;
 import com.google.api.client.util.Data;
 
@@ -86,7 +87,7 @@ public class TemplatesTest extends DnsimpleTestBase {
 
   @Test
   public void testGetTemplate() throws DnsimpleException, IOException {
-    Client client = mockAndExpectClient("https://api.dnsimple.com/v2/1010/templates/1", HttpMethods.GET, null, resource("getTemplate/success.http"));
+    Client client = mockAndExpectClient("https://api.dnsimple.com/v2/1010/templates/1", HttpMethods.GET, new HttpHeaders(), null, resource("getTemplate/success.http"));
 
     String accountId = "1010";
     String templateId = "1";
@@ -147,7 +148,7 @@ public class TemplatesTest extends DnsimpleTestBase {
     attributes.put("name", "A Template");
     attributes.put("short_name", "a_template");
 
-    Client client = mockAndExpectClient("https://api.dnsimple.com/v2/1010/templates/1", HttpMethods.PATCH, attributes, resource("updateTemplate/success.http"));
+    Client client = mockAndExpectClient("https://api.dnsimple.com/v2/1010/templates/1", HttpMethods.PATCH, new HttpHeaders(), attributes, resource("updateTemplate/success.http"));
 
     UpdateTemplateResponse response = client.templates.updateTemplate(accountId, templateId, attributes);
     Template template = response.getData();

--- a/src/test/java/com/dnsimple/TldsTest.java
+++ b/src/test/java/com/dnsimple/TldsTest.java
@@ -15,6 +15,7 @@ import org.junit.Test;
 
 import static org.junit.Assert.*;
 
+import com.google.api.client.http.HttpHeaders;
 import com.google.api.client.http.HttpMethods;
 
 import java.io.IOException;
@@ -84,7 +85,7 @@ public class TldsTest extends DnsimpleTestBase {
 
   @Test
   public void testGetTldExtendedAttributes() throws DnsimpleException, IOException {
-    Client client = mockAndExpectClient("https://api.dnsimple.com/v2/tlds/uk/extended_attributes", HttpMethods.GET, null, resource("getTldExtendedAttributes/success.http"));
+    Client client = mockAndExpectClient("https://api.dnsimple.com/v2/tlds/uk/extended_attributes", HttpMethods.GET, new HttpHeaders(), null, resource("getTldExtendedAttributes/success.http"));
 
     String tldString = "uk";
 
@@ -105,7 +106,7 @@ public class TldsTest extends DnsimpleTestBase {
 
   @Test
   public void testGetTldExtendedAttributesWhenNone() throws DnsimpleException, IOException {
-    Client client = mockAndExpectClient("https://api.dnsimple.com/v2/tlds/com/extended_attributes", HttpMethods.GET, null, resource("getTldExtendedAttributes/success-noattributes.http"));
+    Client client = mockAndExpectClient("https://api.dnsimple.com/v2/tlds/com/extended_attributes", HttpMethods.GET, new HttpHeaders(), null, resource("getTldExtendedAttributes/success-noattributes.http"));
 
     String tldString = "com";
 

--- a/src/test/java/com/dnsimple/VanityNameServersTest.java
+++ b/src/test/java/com/dnsimple/VanityNameServersTest.java
@@ -24,7 +24,7 @@ public class VanityNameServersTest extends DnsimpleTestBase {
     String accountId = "1010";
     String domainId = "example.com";
 
-    Client client = mockAndExpectClient("https://api.dnsimple.com/v2/1010/vanity/example.com", HttpMethods.PUT, null, resource("enableVanityNameServers/success.http"));
+    Client client = mockAndExpectClient("https://api.dnsimple.com/v2/1010/vanity/example.com", HttpMethods.PUT, resource("enableVanityNameServers/success.http"));
 
     EnableVanityNameServersResponse response = client.vanityNameServers.enableVanityNameServers(accountId, domainId);
     List<NameServer> vanityNameServers = response.getData();
@@ -35,7 +35,7 @@ public class VanityNameServersTest extends DnsimpleTestBase {
     String accountId = "1010";
     String domainId = "example.com";
 
-    Client client = mockAndExpectClient("https://api.dnsimple.com/v2/1010/vanity/example.com", HttpMethods.DELETE, null, resource("disableVanityNameServers/success.http"));
+    Client client = mockAndExpectClient("https://api.dnsimple.com/v2/1010/vanity/example.com", HttpMethods.DELETE, resource("disableVanityNameServers/success.http"));
 
     DisableVanityNameServersResponse response = client.vanityNameServers.disableVanityNameServers(accountId, domainId);
     assertEquals(null, response.getData());

--- a/src/test/java/com/dnsimple/WebhooksTest.java
+++ b/src/test/java/com/dnsimple/WebhooksTest.java
@@ -14,6 +14,7 @@ import org.junit.Test;
 
 import static org.junit.Assert.*;
 
+import com.google.api.client.http.HttpHeaders;
 import com.google.api.client.http.HttpMethods;
 import com.google.api.client.util.Data;
 
@@ -76,7 +77,7 @@ public class WebhooksTest extends DnsimpleTestBase {
     HashMap<String, Object> attributes = new HashMap<String, Object>();
     attributes.put("url", "https://webhook.test");
 
-    Client client = mockAndExpectClient("https://api.dnsimple.com/v2/1010/webhooks", HttpMethods.POST, attributes, resource("createWebhook/created.http"));
+    Client client = mockAndExpectClient("https://api.dnsimple.com/v2/1010/webhooks", HttpMethods.POST, new HttpHeaders(), attributes, resource("createWebhook/created.http"));
 
     CreateWebhookResponse response = client.webhooks.createWebhook(accountId, attributes);
     Webhook webhook = response.getData();

--- a/src/test/java/com/dnsimple/ZoneRecordsTest.java
+++ b/src/test/java/com/dnsimple/ZoneRecordsTest.java
@@ -155,7 +155,7 @@ public class ZoneRecordsTest extends DnsimpleTestBase {
     HashMap<String, Object> attributes = new HashMap<String, Object>();
     attributes.put("name", "www");
 
-    Client client = mockAndExpectClient("https://api.dnsimple.com/v2/1/zones/example.com/records/2", HttpMethods.PATCH, attributes, resource("updateZoneRecord/success.http"));
+    Client client = mockAndExpectClient("https://api.dnsimple.com/v2/1/zones/example.com/records/2", HttpMethods.PATCH, new HttpHeaders(), attributes, resource("updateZoneRecord/success.http"));
 
     UpdateZoneRecordResponse response = client.zones.updateZoneRecord(accountId, zoneId, recordId, attributes);
     ZoneRecord record = response.getData();
@@ -164,7 +164,7 @@ public class ZoneRecordsTest extends DnsimpleTestBase {
 
   @Test
   public void testDeleteZoneRecord() throws DnsimpleException, IOException {
-    Client client = mockAndExpectClient("https://api.dnsimple.com/v2/1/zones/example.com/records/2", HttpMethods.DELETE, resource("deleteZoneRecord/success.http"));
+    Client client = mockAndExpectClient("https://api.dnsimple.com/v2/1/zones/example.com/records/2", HttpMethods.DELETE, new HttpHeaders(), null, resource("deleteZoneRecord/success.http"));
 
     String accountId = "1";
     String zoneId = "example.com";

--- a/src/test/java/com/dnsimple/ZoneRecordsTest.java
+++ b/src/test/java/com/dnsimple/ZoneRecordsTest.java
@@ -17,6 +17,7 @@ import org.junit.Test;
 
 import static org.junit.Assert.*;
 
+import com.google.api.client.http.HttpHeaders;
 import com.google.api.client.http.HttpMethods;
 import com.google.api.client.util.Data;
 
@@ -122,10 +123,12 @@ public class ZoneRecordsTest extends DnsimpleTestBase {
   public void testCreateZoneSendsCorrectRequest() throws DnsimpleException, IOException {
     String accountId = "1010";
     String zoneId = "example.com";
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType("application/json");
     HashMap<String, Object> attributes = new HashMap<String, Object>();
     attributes.put("name", "www");
 
-    Client client = expectClient("https://api.dnsimple.com/v2/1010/zones/example.com/records", HttpMethods.POST, new HashMap<String, Object>(), attributes);
+    Client client = expectClient("https://api.dnsimple.com/v2/1010/zones/example.com/records", HttpMethods.POST, headers, attributes);
 
     client.zones.createZoneRecord(accountId, zoneId, attributes);
   }

--- a/src/test/java/com/dnsimple/ZoneRecordsTest.java
+++ b/src/test/java/com/dnsimple/ZoneRecordsTest.java
@@ -125,7 +125,7 @@ public class ZoneRecordsTest extends DnsimpleTestBase {
     HashMap<String, Object> attributes = new HashMap<String, Object>();
     attributes.put("name", "www");
 
-    Client client = expectClient("https://api.dnsimple.com/v2/1010/zones/example.com/records", HttpMethods.POST, attributes);
+    Client client = expectClient("https://api.dnsimple.com/v2/1010/zones/example.com/records", HttpMethods.POST, new HashMap<String, Object>(), attributes);
 
     client.zones.createZoneRecord(accountId, zoneId, attributes);
   }


### PR DESCRIPTION
This branch adds support for setting the access token, used in the Authorization header, as well as the user agent, which is prepended to a default user agent that is specific to the library.

Closes GH-3