### PR TITLE
Update registrar URLs

### DIFF
--- a/src/main/java/com/dnsimple/endpoints/http/RegistrarEndpoint.java
+++ b/src/main/java/com/dnsimple/endpoints/http/RegistrarEndpoint.java
@@ -37,22 +37,22 @@ public class RegistrarEndpoint implements Registrar {
   }
 
   public RegisterDomainResponse registerDomain(String accountId, String domainName, Map<String,Object> attributes) throws DnsimpleException, IOException {
-    HttpResponse response = client.post(accountId + "/registrar/domains/" + domainName + "/register", attributes);
+    HttpResponse response = client.post(accountId + "/registrar/domains/" + domainName + "/registrations", attributes);
     return (RegisterDomainResponse)client.parseResponse(response, RegisterDomainResponse.class);
   }
 
   public RenewDomainResponse renewDomain(String accountId, String domainId, Map<String,Object> attributes) throws DnsimpleException, IOException {
-    HttpResponse response = client.post(accountId + "/registrar/domains/" + domainId + "/renewal", attributes);
+    HttpResponse response = client.post(accountId + "/registrar/domains/" + domainId + "/renewals", attributes);
     return (RenewDomainResponse)client.parseResponse(response, RenewDomainResponse.class);
   }
 
   public TransferDomainResponse transferDomain(String accountId, String domainId, Map<String,Object> attributes) throws DnsimpleException, IOException {
-    HttpResponse response = client.post(accountId + "/registrar/domains/" + domainId + "/transfer", attributes);
+    HttpResponse response = client.post(accountId + "/registrar/domains/" + domainId + "/transfers", attributes);
     return (TransferDomainResponse)client.parseResponse(response, TransferDomainResponse.class);
   }
 
   public TransferDomainOutResponse transferDomainOut(String accountId, String domainId) throws DnsimpleException, IOException {
-    HttpResponse response = client.post(accountId + "/registrar/domains/" + domainId + "/transfer_out");
+    HttpResponse response = client.post(accountId + "/registrar/domains/" + domainId + "/authorize_transfer_out");
     return (TransferDomainOutResponse)client.parseResponse(response, TransferDomainOutResponse.class);
   }
 

--- a/src/test/java/com/dnsimple/RegistrarTest.java
+++ b/src/test/java/com/dnsimple/RegistrarTest.java
@@ -44,7 +44,7 @@ public class RegistrarTest extends DnsimpleTestBase {
     HashMap<String, Object> attributes = new HashMap<String, Object>();
     attributes.put("registrant_id", "10");
 
-    Client client = mockAndExpectClient("https://api.dnsimple.com/v2/1010/registrar/domains/example.com/register", HttpMethods.POST, new HttpHeaders(), attributes, resource("registerDomain/success.http"));
+    Client client = mockAndExpectClient("https://api.dnsimple.com/v2/1010/registrar/domains/example.com/registrations", HttpMethods.POST, new HttpHeaders(), attributes, resource("registerDomain/success.http"));
 
     RegisterDomainResponse response = client.registrar.registerDomain(accountId, name, attributes);
     Domain domain = response.getData();
@@ -69,7 +69,7 @@ public class RegistrarTest extends DnsimpleTestBase {
     HashMap<String, Object> attributes = new HashMap<String, Object>();
     attributes.put("period", "3");
 
-    Client client = mockAndExpectClient("https://api.dnsimple.com/v2/1010/registrar/domains/example.com/renewal", HttpMethods.POST, new HttpHeaders(), attributes, resource("renewDomain/success.http"));
+    Client client = mockAndExpectClient("https://api.dnsimple.com/v2/1010/registrar/domains/example.com/renewals", HttpMethods.POST, new HttpHeaders(), attributes, resource("renewDomain/success.http"));
 
     RenewDomainResponse response = client.registrar.renewDomain(accountId, name, attributes);
     Domain domain = response.getData();
@@ -83,7 +83,7 @@ public class RegistrarTest extends DnsimpleTestBase {
     HashMap<String, Object> attributes = new HashMap<String, Object>();
     attributes.put("period", "3");
 
-    Client client = mockAndExpectClient("https://api.dnsimple.com/v2/1010/registrar/domains/example.com/renewal", HttpMethods.POST, new HttpHeaders(), attributes, resource("renewDomain/error-tooearly.http"));
+    Client client = mockAndExpectClient("https://api.dnsimple.com/v2/1010/registrar/domains/example.com/renewals", HttpMethods.POST, new HttpHeaders(), attributes, resource("renewDomain/error-tooearly.http"));
 
     client.registrar.renewDomain(accountId, name, attributes);
   }
@@ -96,7 +96,7 @@ public class RegistrarTest extends DnsimpleTestBase {
     attributes.put("registrant_id", "1");
     attributes.put("auth_info", "x1y2z3");
 
-    Client client = mockAndExpectClient("https://api.dnsimple.com/v2/1010/registrar/domains/example.com/transfer", HttpMethods.POST, new HttpHeaders(), attributes, resource("transferDomain/success.http"));
+    Client client = mockAndExpectClient("https://api.dnsimple.com/v2/1010/registrar/domains/example.com/transfers", HttpMethods.POST, new HttpHeaders(), attributes, resource("transferDomain/success.http"));
 
     TransferDomainResponse response = client.registrar.transferDomain(accountId, name, attributes);
     Domain domain = response.getData();
@@ -111,7 +111,7 @@ public class RegistrarTest extends DnsimpleTestBase {
     attributes.put("registrant_id", "1");
     attributes.put("auth_info", "x1y2z3");
 
-    Client client = mockAndExpectClient("https://api.dnsimple.com/v2/1010/registrar/domains/example.com/transfer", HttpMethods.POST, new HttpHeaders(), attributes, resource("transferDomain/error-isdnsimple.http"));
+    Client client = mockAndExpectClient("https://api.dnsimple.com/v2/1010/registrar/domains/example.com/transfers", HttpMethods.POST, new HttpHeaders(), attributes, resource("transferDomain/error-isdnsimple.http"));
 
     client.registrar.transferDomain(accountId, name, attributes);
   }
@@ -123,7 +123,7 @@ public class RegistrarTest extends DnsimpleTestBase {
     HashMap<String, Object> attributes = new HashMap<String, Object>();
     attributes.put("registrant_id", "1");
 
-    Client client = mockAndExpectClient("https://api.dnsimple.com/v2/1010/registrar/domains/example.com/transfer", HttpMethods.POST, new HttpHeaders(), attributes, resource("transferDomain/error-missing-authcode.http"));
+    Client client = mockAndExpectClient("https://api.dnsimple.com/v2/1010/registrar/domains/example.com/transfers", HttpMethods.POST, new HttpHeaders(), attributes, resource("transferDomain/error-missing-authcode.http"));
 
     client.registrar.transferDomain(accountId, name, attributes);
   }
@@ -133,7 +133,7 @@ public class RegistrarTest extends DnsimpleTestBase {
     String accountId = "1010";
     String name = "example.com";
 
-    Client client = mockAndExpectClient("https://api.dnsimple.com/v2/1010/registrar/domains/example.com/transfer_out", HttpMethods.POST, new HttpHeaders(), null, resource("transferDomainOut/success.http"));
+    Client client = mockAndExpectClient("https://api.dnsimple.com/v2/1010/registrar/domains/example.com/authorize_transfer_out", HttpMethods.POST, new HttpHeaders(), null, resource("transferDomainOut/success.http"));
 
     TransferDomainOutResponse response = client.registrar.transferDomainOut(accountId, name);
     assertEquals(null, response.getData());


### PR DESCRIPTION
The registrar methods were using our old, URLs that we decided to migrate before API v2 GA.
This PR updates the URLs to the public, [documented](https://developer.dnsimple.com/v2/registrar/) ones.

See dnsimple/dnsimple-developer#147