### PR TITLE
Ignore IntelliJ files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 target
+
+# IntelliJ files
+.idea
+*.iml


### PR DESCRIPTION
This PR adds a couple of entries to the `.gitignore` files to avoid pushing local IntelliJ project files and settings.

This PR doesn't change any implementation or test files, so no behavior change should be expected whatsoever, which means this PR should be safe to merge.