### PR TITLE
Bump Google HTTP client lib dependencies to 1.35.0 and adapt tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,12 +37,12 @@
     <dependency>
       <groupId>com.google.http-client</groupId>
       <artifactId>google-http-client</artifactId>
-      <version>1.34.2</version>
+      <version>1.35.0</version>
     </dependency>
     <dependency>
       <groupId>com.google.http-client</groupId>
       <artifactId>google-http-client-gson</artifactId>
-      <version>1.34.2</version>
+      <version>1.35.0</version>
     </dependency>
     <dependency>
       <groupId>io.mikael</groupId>

--- a/src/test/java/com/dnsimple/ClientTest.java
+++ b/src/test/java/com/dnsimple/ClientTest.java
@@ -31,7 +31,7 @@ public class ClientTest extends DnsimpleTestBase {
   @Test
   public void testUserAgentHeader() throws DnsimpleException, IOException {
     HttpHeaders headers = getDefaultHeaders();
-    headers.setUserAgent("my-user-agent dnsimple-java/" + Dnsimple.VERSION + " Google-HTTP-Java-Client/1.34.2 (gzip)");
+    headers.setUserAgent("my-user-agent dnsimple-java/" + Dnsimple.VERSION + " Google-HTTP-Java-Client/1.35.0 (gzip)");
 
     Client client = mockAndExpectClient("https://api.dnsimple.com/v2/accounts", HttpMethods.GET, headers, null, resource("listAccounts/success-account.http"));
     client.setUserAgent("my-user-agent");

--- a/src/test/java/com/dnsimple/DnsimpleTestBase.java
+++ b/src/test/java/com/dnsimple/DnsimpleTestBase.java
@@ -221,7 +221,7 @@ public abstract class DnsimpleTestBase {
   public HttpHeaders getDefaultHeaders() {
     HttpHeaders headers = new HttpHeaders();
     headers.setAccept("application/json");
-    headers.setUserAgent("dnsimple-java/" + Dnsimple.VERSION + " Google-HTTP-Java-Client/1.34.2 (gzip)");
+    headers.setUserAgent("dnsimple-java/" + Dnsimple.VERSION + " Google-HTTP-Java-Client/1.35.0 (gzip)");
     return headers;
   }
 


### PR DESCRIPTION
This PR updates the Google HTTP client lib dependencies to 1.35.0 and adapts the tests that verify request header contents.

It's important that we aknowledge that merging this PR will make this library incompatible with Android projects under API level 19 as per:

> android: set minimum API level to 19 a.k.a. 4.4 Kit Kat (#1016) (b9a8023), closes #1015

(should be fine, [less than 4.4% of devices are running KitKat](https://gs.statcounter.com/android-version-market-share/mobile-tablet/worldwide))