### PR TITLE
Bugfix/13 delete zone record illegal argument exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### master
+
+- FIXED: Bug that produced an IllegalArgumentException in all requests that are responded with a HTTP 204 No Content ([GH-30](https://github.com/dnsimple/dnsimple-java/pull/30))
+
+  As a result, now we package the Apache HTTP Client library as a transient dependency
+  
 ### Release 0.7.0
 
 - NEW: Added `client.registrar.getDomainTransfer` to retrieve a domain transfer. (dnsimple/dnsimple-java#33)

--- a/src/main/java/com/dnsimple/endpoints/http/HttpEndpointClient.java
+++ b/src/main/java/com/dnsimple/endpoints/http/HttpEndpointClient.java
@@ -175,12 +175,9 @@ public class HttpEndpointClient {
     if (response.getStatusCode() == 204 || response.getContent() == null)
       return buildTypeSafeApiResponse(c);
 
-    InputStream in = response.getContent();
-    try {
+    try (InputStream in = response.getContent()) {
       JsonParser jsonParser = GsonFactory.getDefaultInstance().createJsonParser(in);
-      return (ApiResponse)jsonParser.parse(c);
-    } finally {
-      in.close();
+      return (ApiResponse) jsonParser.parse(c);
     }
   }
 

--- a/src/main/java/com/dnsimple/endpoints/http/HttpEndpointClient.java
+++ b/src/main/java/com/dnsimple/endpoints/http/HttpEndpointClient.java
@@ -172,24 +172,16 @@ public class HttpEndpointClient {
   }
 
   private ApiResponse buildApiResponse(HttpResponse response, Class<?> c) throws IOException {
-    ApiResponse res;
-    if (response.getStatusCode() == 204) {
-      res = buildTypeSafeApiResponse(c);
-    } else {
-      InputStream in = response.getContent();
+    if (response.getStatusCode() == 204 || response.getContent() == null)
+      return buildTypeSafeApiResponse(c);
 
-      if (in == null) {
-        res = buildTypeSafeApiResponse(c);
-      } else {
-        try {
-          JsonParser jsonParser = GsonFactory.getDefaultInstance().createJsonParser(in);
-          res = (ApiResponse)jsonParser.parse(c);
-        } finally {
-          in.close();
-        }
-      }
+    InputStream in = response.getContent();
+    try {
+      JsonParser jsonParser = GsonFactory.getDefaultInstance().createJsonParser(in);
+      return (ApiResponse)jsonParser.parse(c);
+    } finally {
+      in.close();
     }
-    return res;
   }
 
   private ApiResponse buildTypeSafeApiResponse(Class<?> c) {

--- a/src/main/java/com/dnsimple/endpoints/http/HttpEndpointClient.java
+++ b/src/main/java/com/dnsimple/endpoints/http/HttpEndpointClient.java
@@ -163,20 +163,28 @@ public class HttpEndpointClient {
    */
   protected ApiResponse parseResponse(HttpResponse response, Class<?> c) throws IOException {
     ApiResponse res = null;
-    InputStream in = response.getContent();
-
-    if (in == null) {
+    if (response.getStatusCode() == 204)
       try {
         res = (ApiResponse)c.newInstance();
       } catch(ReflectiveOperationException e) {
         throw new RuntimeException("Cannot instantiate " + c, e);
       }
-    } else {
-      try {
-        JsonParser jsonParser = GsonFactory.getDefaultInstance().createJsonParser(in);
-        res = (ApiResponse)jsonParser.parse(c);
-      } finally {
-        in.close();
+    else {
+      InputStream in = response.getContent();
+
+      if (in == null) {
+        try {
+          res = (ApiResponse)c.newInstance();
+        } catch(ReflectiveOperationException e) {
+          throw new RuntimeException("Cannot instantiate " + c, e);
+        }
+      } else {
+        try {
+          JsonParser jsonParser = GsonFactory.getDefaultInstance().createJsonParser(in);
+          res = (ApiResponse)jsonParser.parse(c);
+        } finally {
+          in.close();
+        }
       }
     }
 

--- a/src/main/java/com/dnsimple/endpoints/http/HttpEndpointClient.java
+++ b/src/main/java/com/dnsimple/endpoints/http/HttpEndpointClient.java
@@ -163,6 +163,16 @@ public class HttpEndpointClient {
    */
   protected ApiResponse parseResponse(HttpResponse response, Class<?> c) throws IOException {
     ApiResponse res = null;
+    res = buildApiResponse(response, c);
+
+    res.setHttpRequest(response.getRequest());
+    res.setHttpResponse(response);
+
+    return res;
+  }
+
+  private ApiResponse buildApiResponse(HttpResponse response, Class<?> c) throws IOException {
+    ApiResponse res;
     if (response.getStatusCode() == 204) {
       res = buildTypeSafeApiResponse(c);
     } else {
@@ -179,10 +189,6 @@ public class HttpEndpointClient {
         }
       }
     }
-
-    res.setHttpRequest(response.getRequest());
-    res.setHttpResponse(response);
-
     return res;
   }
 

--- a/src/main/java/com/dnsimple/endpoints/http/HttpEndpointClient.java
+++ b/src/main/java/com/dnsimple/endpoints/http/HttpEndpointClient.java
@@ -163,21 +163,13 @@ public class HttpEndpointClient {
    */
   protected ApiResponse parseResponse(HttpResponse response, Class<?> c) throws IOException {
     ApiResponse res = null;
-    if (response.getStatusCode() == 204)
-      try {
-        res = (ApiResponse)c.newInstance();
-      } catch(ReflectiveOperationException e) {
-        throw new RuntimeException("Cannot instantiate " + c, e);
-      }
-    else {
+    if (response.getStatusCode() == 204) {
+      res = buildTypeSafeApiResponse(c);
+    } else {
       InputStream in = response.getContent();
 
       if (in == null) {
-        try {
-          res = (ApiResponse)c.newInstance();
-        } catch(ReflectiveOperationException e) {
-          throw new RuntimeException("Cannot instantiate " + c, e);
-        }
+        res = buildTypeSafeApiResponse(c);
       } else {
         try {
           JsonParser jsonParser = GsonFactory.getDefaultInstance().createJsonParser(in);
@@ -191,6 +183,16 @@ public class HttpEndpointClient {
     res.setHttpRequest(response.getRequest());
     res.setHttpResponse(response);
 
+    return res;
+  }
+
+  private ApiResponse buildTypeSafeApiResponse(Class<?> c) {
+    ApiResponse res;
+    try {
+      res = (ApiResponse) c.newInstance();
+    } catch (ReflectiveOperationException e) {
+      throw new RuntimeException("Cannot instantiate " + c, e);
+    }
     return res;
   }
 

--- a/src/main/java/com/dnsimple/endpoints/http/HttpEndpointClient.java
+++ b/src/main/java/com/dnsimple/endpoints/http/HttpEndpointClient.java
@@ -182,13 +182,11 @@ public class HttpEndpointClient {
   }
 
   private ApiResponse buildTypeSafeApiResponse(Class<?> c) {
-    ApiResponse res;
     try {
-      res = (ApiResponse) c.newInstance();
+      return (ApiResponse) c.newInstance();
     } catch (ReflectiveOperationException e) {
       throw new RuntimeException("Cannot instantiate " + c, e);
     }
-    return res;
   }
 
   private String versionedPath(String path) {

--- a/src/main/java/com/dnsimple/endpoints/http/HttpEndpointClient.java
+++ b/src/main/java/com/dnsimple/endpoints/http/HttpEndpointClient.java
@@ -162,8 +162,7 @@ public class HttpEndpointClient {
    * @throws IOException Any IO errors
    */
   protected ApiResponse parseResponse(HttpResponse response, Class<?> c) throws IOException {
-    ApiResponse res = null;
-    res = buildApiResponse(response, c);
+    ApiResponse res = buildApiResponse(response, c);
 
     res.setHttpRequest(response.getRequest());
     res.setHttpResponse(response);


### PR DESCRIPTION
FIxes #13

This PR handles a case where the client fails to delete a zone record due to being unable to parse the API's response.

After studying this unexpected behavior, we discovered that other operations leading to `HTTP 204 No Content` responses will also fail with the same error.

We have discarded a problem in the API responses and have established that the way we mock HTTP responses in our tests is making it difficult to reproduce the issue reported in #13.

We were able to reproduce the issue in a test by artificially modifying a response and were able to confirm that this PR is a fix for the issue. 

The fix comes from completely skipping the parsing step if we get an HTTP 204, which we know it's going to be (it should be) empty.