### PR TITLE
Support making HTTP PATCH requests thanks to ApacheHttpTransport

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,11 @@
       <version>1.35.0</version>
     </dependency>
     <dependency>
+      <groupId>com.google.http-client</groupId>
+      <artifactId>google-http-client-apache-v2</artifactId>
+      <version>1.35.0</version>
+    </dependency>
+    <dependency>
       <groupId>io.mikael</groupId>
       <artifactId>urlbuilder</artifactId>
       <version>2.0.9</version>

--- a/src/main/java/com/dnsimple/endpoints/http/HttpEndpointClient.java
+++ b/src/main/java/com/dnsimple/endpoints/http/HttpEndpointClient.java
@@ -13,7 +13,7 @@ import com.google.api.client.http.HttpHeaders;
 import com.google.api.client.http.HttpMethods;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.http.HttpResponseException;
-import com.google.api.client.http.javanet.NetHttpTransport;
+import com.google.api.client.http.apache.v2.ApacheHttpTransport;
 import com.google.api.client.http.json.JsonHttpContent;
 import com.google.api.client.json.gson.GsonFactory;
 import com.google.api.client.json.JsonParser;
@@ -38,7 +38,7 @@ public class HttpEndpointClient {
   private String userAgent;
 
   public HttpEndpointClient() {
-    this.transport = new NetHttpTransport();
+    this.transport = new ApacheHttpTransport();
   }
 
   /**


### PR DESCRIPTION
Fixes #31

This PR applies the fix suggested at https://github.com/googleapis/google-http-java-client/issues/167 to support making HTTP PATCH requests with the Google HTTP client we're using.

This PR provides no tests for this change because the only way to effectively test this at the moment is by doing a live request to the API.

I verified the reproduction of the error and the fix using the test method I attached to #31.

Once #30 is merged, we will be able to write a regression test for #31 without requiring to make a live request.

