### PR TITLE
Implement client methods for Transfer API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### master
+
+- NEW: Added `client.registrar.getDomainTransfer` to retrieve a domain transfer. (dnsimple/dnsimple-java#33)
+- NEW: Added `client.registrar.cancelDomainTransfer` to cancel an in progress domain transfer. (dnsimple/dnsimple-java#33)
+- NEW: Added `DomainTransfer.getStatusDescription()` to identify the failure reason of a transfer. (dnsimple/dnsimple-java#33).
+
 ### Release 0.6.0
 
 - NEW: Added WHOIS privacy renewal (GH-12)

--- a/src/main/java/com/dnsimple/Registrar.java
+++ b/src/main/java/com/dnsimple/Registrar.java
@@ -84,6 +84,34 @@ public interface Registrar {
   public TransferDomainResponse transferDomain(String accountId, String domainId, Map<String,Object> attributes) throws DnsimpleException, IOException;
 
   /**
+   * Retrieves the details of an existing domain transfer.
+   *
+   * @see <a href="https://developer.dnsimple.com/v2/registrar/#getDomainTransfer">https://developer.dnsimple.com/v2/registrar/#getDomainTransfer</a>
+   *
+   * @param accountId The account ID
+   * @param domainId The domain name or ID
+   * @param domainTransferId The domain transfer ID
+   * @return The transfer domain response
+   * @throws DnsimpleException Any API error
+   * @throws IOException Any IO error
+   */
+  public TransferDomainResponse getDomainTransfer(String accountId, String domainId, String domainTransferId) throws DnsimpleException, IOException;
+
+  /**
+   * Cancels an in progress domain transfer.
+   *
+   * @see <a href="https://developer.dnsimple.com/v2/registrar/#cancelDomainTransfer">https://developer.dnsimple.com/v2/registrar/#cancelDomainTransfer</a>
+   *
+   * @param accountId The account ID
+   * @param domainId The domain name or ID
+   * @param domainTransferId The domain transfer ID
+   * @return The transfer domain response
+   * @throws DnsimpleException Any API error
+   * @throws IOException Any IO error
+   */
+  public TransferDomainResponse cancelDomainTransfer(String accountId, String domainId, String domainTransferId) throws DnsimpleException, IOException;
+
+  /**
    * Requests the transfer of a domain out of DNSimple.
    *
    * @see <a href="https://developer.dnsimple.com/v2/registrar/#transfer-out">https://developer.dnsimple.com/v2/registrar/#transfer-out</a>

--- a/src/main/java/com/dnsimple/data/DomainTransfer.java
+++ b/src/main/java/com/dnsimple/data/DomainTransfer.java
@@ -54,7 +54,9 @@ public class DomainTransfer {
     return whoisPrivacy;
   }
 
-  public String getStatusDescription() { return statusDescription; }
+  public String getStatusDescription() { 
+    return statusDescription; 
+  }
 
   public String getCreatedAt() {
     return createdAt;

--- a/src/main/java/com/dnsimple/data/DomainTransfer.java
+++ b/src/main/java/com/dnsimple/data/DomainTransfer.java
@@ -21,6 +21,9 @@ public class DomainTransfer {
   @Key("whois_privacy")
   private boolean whoisPrivacy;
 
+  @Key("status_description")
+  private String statusDescription;
+
   @Key("created_at")
   private String createdAt;
 
@@ -50,6 +53,8 @@ public class DomainTransfer {
   public boolean hasWhoisPrivacy() {
     return whoisPrivacy;
   }
+
+  public String getStatusDescription() { return statusDescription; }
 
   public String getCreatedAt() {
     return createdAt;

--- a/src/main/java/com/dnsimple/endpoints/http/RegistrarEndpoint.java
+++ b/src/main/java/com/dnsimple/endpoints/http/RegistrarEndpoint.java
@@ -52,6 +52,16 @@ public class RegistrarEndpoint implements Registrar {
     return (TransferDomainResponse)client.parseResponse(response, TransferDomainResponse.class);
   }
 
+  public TransferDomainResponse getDomainTransfer(String accountId, String domainId, String domainTransferId) throws DnsimpleException, IOException {
+    HttpResponse response = client.get(accountId + "/registrar/domains/" + domainId + "/transfers/" + domainTransferId);
+    return (TransferDomainResponse)client.parseResponse(response, TransferDomainResponse.class);
+  }
+
+  public TransferDomainResponse cancelDomainTransfer(String accountId, String domainId, String domainTransferId) throws DnsimpleException, IOException {
+    HttpResponse response = client.delete(accountId + "/registrar/domains/" + domainId + "/transfers/" + domainTransferId);
+    return (TransferDomainResponse)client.parseResponse(response, TransferDomainResponse.class);
+  }
+
   public TransferDomainOutResponse transferDomainOut(String accountId, String domainId) throws DnsimpleException, IOException {
     HttpResponse response = client.post(accountId + "/registrar/domains/" + domainId + "/authorize_transfer_out");
     return (TransferDomainOutResponse)client.parseResponse(response, TransferDomainOutResponse.class);

--- a/src/test/java/com/dnsimple/RegistrarTest.java
+++ b/src/test/java/com/dnsimple/RegistrarTest.java
@@ -102,6 +102,48 @@ public class RegistrarTest extends DnsimpleTestBase {
     assertEquals(1, transfer.getId().intValue());
   }
 
+  @Test
+  public void testGetDomainTransfer() throws DnsimpleException, IOException  {
+    String accountId = "1010";
+    String name = "example.com";
+    String transferId = "42";
+    Client client = mockAndExpectClient("https://api.dnsimple.com/v2/1010/registrar/domains/example.com/transfers/42", HttpMethods.GET, new HttpHeaders(), null, resource("getDomainTransfer/success.http"));
+
+    TransferDomainResponse response = client.registrar.getDomainTransfer(accountId, name, transferId);
+    DomainTransfer transfer = response.getData();
+
+    assertEquals(42, transfer.getId().intValue());
+    assertEquals(2, transfer.getDomainId().intValue());
+    assertEquals(3, transfer.getRegistrantId().intValue());
+    assertEquals("cancelled", transfer.getState());
+    assertFalse(transfer.hasAutoRenew());
+    assertFalse(transfer.hasWhoisPrivacy());
+    assertEquals("Canceled by customer", transfer.getStatusDescription());
+    assertEquals("2020-04-27T18:08:44Z", transfer.getCreatedAt());
+    assertEquals("2020-04-27T18:20:01Z", transfer.getUpdatedAt());
+  }
+
+  @Test
+  public void testCancelDomainTransfer() throws DnsimpleException, IOException  {
+    String accountId = "1010";
+    String name = "example.com";
+    String transferId = "42";
+    Client client = mockAndExpectClient("https://api.dnsimple.com/v2/1010/registrar/domains/example.com/transfers/42", HttpMethods.DELETE, new HttpHeaders(), null, resource("cancelDomainTransfer/success.http"));
+
+    TransferDomainResponse response = client.registrar.cancelDomainTransfer(accountId, name, transferId);
+    DomainTransfer transfer = response.getData();
+
+    assertEquals(42, transfer.getId().intValue());
+    assertEquals(6, transfer.getDomainId().intValue());
+    assertEquals(1, transfer.getRegistrantId().intValue());
+    assertEquals("transferring", transfer.getState());
+    assertTrue(transfer.hasAutoRenew());
+    assertFalse(transfer.hasWhoisPrivacy());
+    assertTrue(transfer.getStatusDescription().isEmpty());
+    assertEquals("2020-04-24T19:19:03Z", transfer.getCreatedAt());
+    assertEquals("2020-04-24T19:19:15Z", transfer.getUpdatedAt());
+  }
+
   @Test(expected=DnsimpleException.class)
   public void testTransferDomainAlreadyInDnsimple() throws DnsimpleException, IOException {
     String accountId = "1010";

--- a/src/test/resources/com/dnsimple/cancelDomainTransfer/success.http
+++ b/src/test/resources/com/dnsimple/cancelDomainTransfer/success.http
@@ -1,0 +1,30 @@
+HTTP/1.1 202 Accepted
+Server: nginx
+Date: Wed, 29 Apr 2020 19:49:41 GMT
+Content-Type: application/json; charset=utf-8
+Transfer-Encoding: chunked
+Connection: keep-alive
+Status: 202 Accepted
+X-RateLimit-Limit: 2400
+X-RateLimit-Remaining: 2397
+X-RateLimit-Reset: 1588193270
+ETag: W/"8404bf2739e44e9f69f3a5199466776d"
+Cache-Control: no-store, must-revalidate, private, max-age=0
+X-Request-Id: 10d75bcf-0066-4d38-98a2-dc18dd5b6f4c
+X-Runtime: 1.752154
+Strict-Transport-Security: max-age=31536000
+
+{
+  "data": {
+    "id": 42,
+    "domain_id": 6,
+    "registrant_id": 1,
+    "state": "transferring",
+    "auto_renew": true,
+    "whois_privacy": false,
+    "premium_price": null,
+    "status_description": null,
+    "created_at": "2020-04-24T19:19:03Z",
+    "updated_at": "2020-04-24T19:19:15Z"
+  }
+}

--- a/src/test/resources/com/dnsimple/getDomainTransfer/success.http
+++ b/src/test/resources/com/dnsimple/getDomainTransfer/success.http
@@ -1,0 +1,30 @@
+HTTP/1.1 200 OK
+Server: nginx
+Date: Mon, 27 Apr 2020 19:40:00 GMT
+Content-Type: application/json; charset=utf-8
+Transfer-Encoding: chunked
+Connection: keep-alive
+Status: 200 OK
+X-RateLimit-Limit: 2400
+X-RateLimit-Remaining: 2398
+X-RateLimit-Reset: 1588019949
+ETag: W/"8404bf2739e44e9f69f3a5199466776d"
+Cache-Control: max-age=0, private, must-revalidate
+X-Request-Id: 4818d867-1f72-4619-ab46-d345e6dd25eb
+X-Runtime: 0.092854
+Strict-Transport-Security: max-age=31536000
+
+{
+  "data": {
+    "id": 42,
+    "domain_id": 2,
+    "registrant_id": 3,
+    "state": "cancelled",
+    "auto_renew": false,
+    "whois_privacy": false,
+    "premium_price": null,
+    "status_description": "Canceled by customer",
+    "created_at": "2020-04-27T18:08:44Z",
+    "updated_at": "2020-04-27T18:20:01Z"
+  }
+}


### PR DESCRIPTION
This commit introduces two client methods for the new features in
TransferAPI:
- getDomainTransfer - Retrieves the information for a specific domain
transfer
- cancelDomainTransfer - Cancels an in progress domain transfer

It also adds the new status_description field in the DomainTransfer
response.