### PR TITLE
Deprecate Domain `expiresOn` in favor of `expiresAt`

### DIFF
--- a/src/main/java/com/dnsimple/data/Domain.java
+++ b/src/main/java/com/dnsimple/data/Domain.java
@@ -1,8 +1,6 @@
 package com.dnsimple.data;
 
 import com.google.api.client.util.Key;
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 
 public class Domain {
   @Key("id")
@@ -19,9 +17,6 @@ public class Domain {
 
   @Key("unicode_name")
   private String unicodeName;
-
-  @Key("token")
-  private String token;
 
   @Key("state")
   private String state;
@@ -61,10 +56,6 @@ public class Domain {
     return unicodeName;
   }
 
-  public String getToken() {
-    return token;
-  }
-
   public String getState() {
     return state;
   }
@@ -87,11 +78,7 @@ public class Domain {
    */
   @Deprecated
   public String getExpiresOn() {
-    if(getExpiresAt() != null) {
-        LocalDateTime parsed = LocalDateTime.parse(getExpiresAt(), DateTimeFormatter.ISO_DATE_TIME);
-        return parsed.toLocalDate().format(DateTimeFormatter.ISO_DATE);
-    }
-    return null;
+    return expiresAt != null ? expiresAt.substring(0, 10) : null;
   }
 
   public String getCreatedAt() {

--- a/src/main/java/com/dnsimple/data/Domain.java
+++ b/src/main/java/com/dnsimple/data/Domain.java
@@ -1,6 +1,8 @@
 package com.dnsimple.data;
 
 import com.google.api.client.util.Key;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 public class Domain {
   @Key("id")
@@ -30,8 +32,8 @@ public class Domain {
   @Key("private_whois")
   private boolean privateWhois;
 
-  @Key("expires_on")
-  private String expiresOn;
+  @Key("expires_at")
+  private String expiresAt;
 
   @Key("created_at")
   private String createdAt;
@@ -75,8 +77,21 @@ public class Domain {
     return privateWhois;
   }
 
+  public String getExpiresAt() {
+    return expiresAt;
+  }
+
+  /**
+   * @deprecated use {@link Domain#getExpiresAt()} instead.
+   * @return the expiration date in {@link DateTimeFormatter#ISO_DATE} pattern.
+   */
+  @Deprecated
   public String getExpiresOn() {
-    return expiresOn;
+    if(getExpiresAt() != null) {
+        LocalDateTime parsed = LocalDateTime.parse(getExpiresAt(), DateTimeFormatter.ISO_DATE_TIME);
+        return parsed.toLocalDate().format(DateTimeFormatter.ISO_DATE);
+    }
+    return null;
   }
 
   public String getCreatedAt() {

--- a/src/test/java/com/dnsimple/DomainsTest.java
+++ b/src/test/java/com/dnsimple/DomainsTest.java
@@ -85,7 +85,6 @@ public class DomainsTest extends DnsimpleTestBase {
     assertThat(domain.getRegistrantId(), is(2715));
     assertThat(domain.getName(), is("example-alpha.com"));
     assertThat(domain.getUnicodeName(), is("example-alpha.com"));
-    assertThat(domain.getToken(), isEmptyOrNullString());
     assertThat(domain.getState(), is("registered"));
     assertThat(domain.getAutoRenew(), is(false));
     assertThat(domain.getPrivateWhois(), is(false));

--- a/src/test/java/com/dnsimple/DomainsTest.java
+++ b/src/test/java/com/dnsimple/DomainsTest.java
@@ -44,9 +44,9 @@ public class DomainsTest extends DnsimpleTestBase {
 
   @Test
   public void testListDomainsSupportsSorting() throws DnsimpleException, IOException {
-    client.domains.listDomains("1", singletonMap("sort", "expires_on:asc"));
+    client.domains.listDomains("1", singletonMap("sort", "expiration:asc"));
     assertThat(server.getRecordedRequest().getMethod(), is(GET));
-    assertThat(server.getRecordedRequest().getPath(), is("/v2/1/domains?sort=expires_on:asc"));
+    assertThat(server.getRecordedRequest().getPath(), is("/v2/1/domains?sort=expiration:asc"));
   }
 
   @Test
@@ -64,7 +64,7 @@ public class DomainsTest extends DnsimpleTestBase {
 
     List<Domain> domains = client.domains.listDomains("1").getData();
     assertThat(domains, hasSize(2));
-    assertThat(domains.get(0).getId(), is(1));
+    assertThat(domains.get(0).getId(), is(181984));
   }
 
   @Test
@@ -80,18 +80,19 @@ public class DomainsTest extends DnsimpleTestBase {
     server.stubFixtureAt("getDomain/success.http");
 
     Domain domain = client.domains.getDomain("1", "example.com").getData();
-    assertThat(domain.getId(), is(1));
-    assertThat(domain.getAccountId(), is(1010));
-    assertThat(domain.getRegistrantId(), is(0));
+    assertThat(domain.getId(), is(181984));
+    assertThat(domain.getAccountId(), is(1385));
+    assertThat(domain.getRegistrantId(), is(2715));
     assertThat(domain.getName(), is("example-alpha.com"));
     assertThat(domain.getUnicodeName(), is("example-alpha.com"));
-    assertThat(domain.getToken(), is("domain-token"));
-    assertThat(domain.getState(), is("hosted"));
+    assertThat(domain.getToken(), isEmptyOrNullString());
+    assertThat(domain.getState(), is("registered"));
     assertThat(domain.getAutoRenew(), is(false));
     assertThat(domain.getPrivateWhois(), is(false));
-    assertThat(domain.getExpiresOn(), isEmptyOrNullString());
-    assertThat(domain.getCreatedAt(), is("2014-12-06T15:56:55Z"));
-    assertThat(domain.getUpdatedAt(), is("2015-12-09T00:20:56Z"));
+    assertThat(domain.getExpiresOn(), is("2021-06-05"));
+    assertThat(domain.getExpiresAt(), is("2021-06-05T02:15:00Z"));
+    assertThat(domain.getCreatedAt(), is("2020-06-04T19:15:14Z"));
+    assertThat(domain.getUpdatedAt(), is("2020-06-04T19:15:21Z"));
   }
 
   @Test
@@ -119,7 +120,7 @@ public class DomainsTest extends DnsimpleTestBase {
     server.stubFixtureAt("createDomain/created.http");
 
     CreateDomainResponse response = client.domains.createDomain("1", singletonMap("name", "example.com"));
-    assertThat(response.getData().getId(), is(1));
+    assertThat(response.getData().getId(), is(181985));
   }
 
   @Test

--- a/src/test/java/com/dnsimple/RegistrarTest.java
+++ b/src/test/java/com/dnsimple/RegistrarTest.java
@@ -8,8 +8,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isEmptyOrNullString;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 
 import com.dnsimple.data.DomainAvailability;
 import com.dnsimple.data.DomainRegistration;
@@ -19,7 +17,6 @@ import com.dnsimple.exception.DnsimpleException;
 import com.dnsimple.response.RegisterDomainResponse;
 import com.dnsimple.response.TransferDomainOutResponse;
 import com.dnsimple.response.TransferDomainResponse;
-import com.google.api.client.http.HttpMethods;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;

--- a/src/test/java/com/dnsimple/RegistrarTest.java
+++ b/src/test/java/com/dnsimple/RegistrarTest.java
@@ -101,40 +101,40 @@ public class RegistrarTest extends DnsimpleTestBase {
   public void testGetDomainTransfer() throws DnsimpleException, IOException {
     server.stubFixtureAt("getDomainTransfer/success.http");
 
-    TransferDomainResponse response = client.registrar.getDomainTransfer("1010", "example.com", "42");
-    assertThat(server.getRecordedRequest().getPath(), is("/v2/1010/registrar/domains/example.com/transfers/42"));
+    TransferDomainResponse response = client.registrar.getDomainTransfer("1010", "example.com", "361");
+    assertThat(server.getRecordedRequest().getPath(), is("/v2/1010/registrar/domains/example.com/transfers/361"));
     assertThat(server.getRecordedRequest().getMethod(), is(GET));
 
     DomainTransfer transfer = response.getData();
-    assertThat(transfer.getId(), is(42));
-    assertThat(transfer.getDomainId(), is(2));
-    assertThat(transfer.getRegistrantId(), is(3));
+    assertThat(transfer.getId(), is(361));
+    assertThat(transfer.getDomainId(), is(182245));
+    assertThat(transfer.getRegistrantId(), is(2715));
     assertThat(transfer.getState(), is("cancelled"));
     assertThat(transfer.hasAutoRenew(), is(false));
     assertThat(transfer.hasWhoisPrivacy(), is(false));
     assertThat(transfer.getStatusDescription(), is("Canceled by customer"));
-    assertThat(transfer.getCreatedAt(), is("2020-04-27T18:08:44Z"));
-    assertThat(transfer.getUpdatedAt(), is("2020-04-27T18:20:01Z"));
+    assertThat(transfer.getCreatedAt(), is("2020-06-05T18:08:00Z"));
+    assertThat(transfer.getUpdatedAt(), is("2020-06-05T18:10:01Z"));
   }
 
   @Test
   public void testCancelDomainTransfer() throws DnsimpleException, IOException {
     server.stubFixtureAt("cancelDomainTransfer/success.http");
 
-    TransferDomainResponse response = client.registrar.cancelDomainTransfer("1010", "example.com", "42");
-    assertThat(server.getRecordedRequest().getPath(), is("/v2/1010/registrar/domains/example.com/transfers/42"));
+    TransferDomainResponse response = client.registrar.cancelDomainTransfer("1010", "example.com", "361");
+    assertThat(server.getRecordedRequest().getPath(), is("/v2/1010/registrar/domains/example.com/transfers/361"));
     assertThat(server.getRecordedRequest().getMethod(), is(DELETE));
 
     DomainTransfer transfer = response.getData();
-    assertThat(transfer.getId(), is(42));
-    assertThat(transfer.getDomainId(), is(6));
-    assertThat(transfer.getRegistrantId(), is(1));
+    assertThat(transfer.getId(), is(361));
+    assertThat(transfer.getDomainId(), is(182245));
+    assertThat(transfer.getRegistrantId(), is(2715));
     assertThat(transfer.getState(), is("transferring"));
-    assertThat(transfer.hasAutoRenew(), is(true));
+    assertThat(transfer.hasAutoRenew(), is(false));
     assertThat(transfer.hasWhoisPrivacy(), is(false));
     assertThat(transfer.getStatusDescription(), isEmptyOrNullString());
-    assertThat(transfer.getCreatedAt(), is("2020-04-24T19:19:03Z"));
-    assertThat(transfer.getUpdatedAt(), is("2020-04-24T19:19:15Z"));
+    assertThat(transfer.getCreatedAt(), is("2020-06-05T18:08:00Z"));
+    assertThat(transfer.getUpdatedAt(), is("2020-06-05T18:08:04Z"));
   }
 
   @Test(expected = DnsimpleException.class)

--- a/src/test/resources/com/dnsimple/cancelDomainTransfer/success.http
+++ b/src/test/resources/com/dnsimple/cancelDomainTransfer/success.http
@@ -1,30 +1,19 @@
 HTTP/1.1 202 Accepted
 Server: nginx
-Date: Wed, 29 Apr 2020 19:49:41 GMT
+Date: Fri, 05 Jun 2020 18:09:42 GMT
 Content-Type: application/json; charset=utf-8
 Transfer-Encoding: identity
 Connection: keep-alive
-Status: 202 Accepted
 X-RateLimit-Limit: 2400
-X-RateLimit-Remaining: 2397
-X-RateLimit-Reset: 1588193270
-ETag: W/"8404bf2739e44e9f69f3a5199466776d"
-Cache-Control: no-store, must-revalidate, private, max-age=0
-X-Request-Id: 10d75bcf-0066-4d38-98a2-dc18dd5b6f4c
-X-Runtime: 1.752154
-Strict-Transport-Security: max-age=31536000
+X-RateLimit-Remaining: 2394
+X-RateLimit-Reset: 1591384034
+Cache-Control: no-cache
+X-Request-Id: 3cf6dcfa-0bb5-439e-863a-af2ef08bc830
+X-Runtime: 0.912731
+X-Frame-Options: DENY
+X-Content-Type-Options: nosniff
+X-XSS-Protection: 1; mode=block
+X-Download-Options: noopen
+X-Permitted-Cross-Domain-Policies: none
 
-{
-  "data": {
-    "id": 42,
-    "domain_id": 6,
-    "registrant_id": 1,
-    "state": "transferring",
-    "auto_renew": true,
-    "whois_privacy": false,
-    "premium_price": null,
-    "status_description": null,
-    "created_at": "2020-04-24T19:19:03Z",
-    "updated_at": "2020-04-24T19:19:15Z"
-  }
-}
+{"data":{"id":361,"domain_id":182245,"registrant_id":2715,"state":"transferring","auto_renew":false,"whois_privacy":false,"status_description":null,"created_at":"2020-06-05T18:08:00Z","updated_at":"2020-06-05T18:08:04Z"}}

--- a/src/test/resources/com/dnsimple/createDomain/created.http
+++ b/src/test/resources/com/dnsimple/createDomain/created.http
@@ -1,16 +1,21 @@
 HTTP/1.1 201 Created
 Server: nginx
-Date: Fri, 18 Dec 2015 16:38:07 GMT
+Date: Thu, 04 Jun 2020 19:47:05 GMT
 Content-Type: application/json; charset=utf-8
 Transfer-Encoding: identity
 Connection: keep-alive
-X-RateLimit-Limit: 4000
-X-RateLimit-Remaining: 3986
-X-RateLimit-Reset: 1450456686
-ETag: W/"87e018b900e5f210c3236f63d3b2f4df"
+X-RateLimit-Limit: 2400
+X-RateLimit-Remaining: 2378
+X-RateLimit-Reset: 1591300248
+ETag: W/"399e70627412fa31dba332feca5e8ec1"
 Cache-Control: max-age=0, private, must-revalidate
-X-Request-Id: 0d6f1ea7-f702-4317-85f0-04874b69315d
-X-Runtime: 0.257489
+X-Request-Id: ee897eee-36cc-4b7f-be15-f4627f344bf9
+X-Runtime: 0.194561
+X-Frame-Options: DENY
+X-Content-Type-Options: nosniff
+X-XSS-Protection: 1; mode=block
+X-Download-Options: noopen
+X-Permitted-Cross-Domain-Policies: none
 Strict-Transport-Security: max-age=31536000
 
-{"data":{"id":1,"account_id":1010,"registrant_id":null,"name":"example-alpha.com","unicode_name":"example-alpha.com","token":"domain-token","state":"hosted","auto_renew":false,"private_whois":false,"expires_on":null,"created_at":"2014-12-06T15:56:55Z","updated_at":"2015-12-09T00:20:56Z"}}
+{"data":{"id":181985,"account_id":1385,"registrant_id":null,"name":"example-beta.com","unicode_name":"example-beta.com","state":"hosted","auto_renew":false,"private_whois":false,"expires_on":null,"expires_at":null,"created_at":"2020-06-04T19:47:05Z","updated_at":"2020-06-04T19:47:05Z"}}

--- a/src/test/resources/com/dnsimple/getDomain/success.http
+++ b/src/test/resources/com/dnsimple/getDomain/success.http
@@ -1,16 +1,21 @@
 HTTP/1.1 200 OK
 Server: nginx
-Date: Wed, 16 Dec 2015 21:54:55 GMT
+Date: Thu, 04 Jun 2020 19:37:22 GMT
 Content-Type: application/json; charset=utf-8
 Transfer-Encoding: identity
 Connection: keep-alive
-X-RateLimit-Limit: 4000
-X-RateLimit-Remaining: 3993
-X-RateLimit-Reset: 1450302894
-ETag: W/"e7282090a87379d1fa3507ba6bfd1721"
+X-RateLimit-Limit: 2400
+X-RateLimit-Remaining: 2379
+X-RateLimit-Reset: 1591300247
+ETag: W/"ff4a8463ecca39d4869695d66de60043"
 Cache-Control: max-age=0, private, must-revalidate
-X-Request-Id: 3d8da18a-b8b2-4bfd-827c-860da837c80f
-X-Runtime: 0.020346
+X-Request-Id: 2e8259ab-c933-487e-8f85-d23f1cdf62fa
+X-Runtime: 0.019482
+X-Frame-Options: DENY
+X-Content-Type-Options: nosniff
+X-XSS-Protection: 1; mode=block
+X-Download-Options: noopen
+X-Permitted-Cross-Domain-Policies: none
 Strict-Transport-Security: max-age=31536000
 
-{"data":{"id":1,"account_id":1010,"registrant_id":null,"name":"example-alpha.com","unicode_name":"example-alpha.com","token":"domain-token","state":"hosted","auto_renew":false,"private_whois":false,"expires_on":null,"created_at":"2014-12-06T15:56:55Z","updated_at":"2015-12-09T00:20:56Z"}}
+{"data":{"id":181984,"account_id":1385,"registrant_id":2715,"name":"example-alpha.com","unicode_name":"example-alpha.com","state":"registered","auto_renew":false,"private_whois":false,"expires_on":"2021-06-05","expires_at":"2021-06-05T02:15:00Z","created_at":"2020-06-04T19:15:14Z","updated_at":"2020-06-04T19:15:21Z"}}

--- a/src/test/resources/com/dnsimple/getDomainTransfer/success.http
+++ b/src/test/resources/com/dnsimple/getDomainTransfer/success.http
@@ -1,30 +1,21 @@
 HTTP/1.1 200 OK
 Server: nginx
-Date: Mon, 27 Apr 2020 19:40:00 GMT
+Date: Fri, 05 Jun 2020 18:23:53 GMT
 Content-Type: application/json; charset=utf-8
 Transfer-Encoding: identity
 Connection: keep-alive
-Status: 200 OK
 X-RateLimit-Limit: 2400
-X-RateLimit-Remaining: 2398
-X-RateLimit-Reset: 1588019949
-ETag: W/"8404bf2739e44e9f69f3a5199466776d"
+X-RateLimit-Remaining: 2392
+X-RateLimit-Reset: 1591384034
+ETag: W/"80c5827934c13b1ca87a587d96e7d1e8"
 Cache-Control: max-age=0, private, must-revalidate
-X-Request-Id: 4818d867-1f72-4619-ab46-d345e6dd25eb
-X-Runtime: 0.092854
+X-Request-Id: 9f4959ee-06a9-488c-906e-27a570cafbbf
+X-Runtime: 0.078429
+X-Frame-Options: DENY
+X-Content-Type-Options: nosniff
+X-XSS-Protection: 1; mode=block
+X-Download-Options: noopen
+X-Permitted-Cross-Domain-Policies: none
 Strict-Transport-Security: max-age=31536000
 
-{
-  "data": {
-    "id": 42,
-    "domain_id": 2,
-    "registrant_id": 3,
-    "state": "cancelled",
-    "auto_renew": false,
-    "whois_privacy": false,
-    "premium_price": null,
-    "status_description": "Canceled by customer",
-    "created_at": "2020-04-27T18:08:44Z",
-    "updated_at": "2020-04-27T18:20:01Z"
-  }
-}
+{"data":{"id":361,"domain_id":182245,"registrant_id":2715,"state":"cancelled","auto_renew":false,"whois_privacy":false,"status_description":"Canceled by customer","created_at":"2020-06-05T18:08:00Z","updated_at":"2020-06-05T18:10:01Z"}}

--- a/src/test/resources/com/dnsimple/listDomains/success.http
+++ b/src/test/resources/com/dnsimple/listDomains/success.http
@@ -1,16 +1,21 @@
 HTTP/1.1 200 OK
 Server: nginx
-Date: Wed, 16 Dec 2015 13:36:11 GMT
+Date: Thu, 04 Jun 2020 19:54:16 GMT
 Content-Type: application/json; charset=utf-8
 Transfer-Encoding: identity
 Connection: keep-alive
-X-RateLimit-Limit: 4000
-X-RateLimit-Remaining: 3997
-X-RateLimit-Reset: 1450272970
-ETag: W/"2679531e6cce6cd326f255255d7a0005"
+X-RateLimit-Limit: 2400
+X-RateLimit-Remaining: 2399
+X-RateLimit-Reset: 1591304056
+ETag: W/"732eac2d85c19810f4e84dbc0eaafb9d"
 Cache-Control: max-age=0, private, must-revalidate
-X-Request-Id: a87f1b44-150a-4ed0-b7da-9301fa1465b0
-X-Runtime: 0.093714
+X-Request-Id: 458d7b96-bb1a-469a-817e-4fd65c0f1db3
+X-Runtime: 0.125593
+X-Frame-Options: DENY
+X-Content-Type-Options: nosniff
+X-XSS-Protection: 1; mode=block
+X-Download-Options: noopen
+X-Permitted-Cross-Domain-Policies: none
 Strict-Transport-Security: max-age=31536000
 
-{"data":[{"id":1,"account_id":1010,"registrant_id":null,"name":"example-alpha.com","unicode_name":"example-alpha.com","token":"domain-token","state":"hosted","auto_renew":false,"private_whois":false,"expires_on":null,"created_at":"2014-12-06T15:56:55Z","updated_at":"2015-12-09T00:20:56Z"},{"id":2,"account_id":1010,"registrant_id":21,"name":"example-beta.com","unicode_name":"example-beta.com","token":"domain-token","state":"registered","auto_renew":false,"private_whois":false,"expires_on":"2015-12-06","created_at":"2014-12-06T15:46:52Z","updated_at":"2015-12-09T00:20:53Z"}],"pagination":{"current_page":1,"per_page":30,"total_entries":2,"total_pages":1}}
+{"data":[{"id":181984,"account_id":1385,"registrant_id":2715,"name":"example-alpha.com","unicode_name":"example-alpha.com","state":"registered","auto_renew":false,"private_whois":false,"expires_on":"2021-06-05","expires_at":"2021-06-05T02:15:00Z","created_at":"2020-06-04T19:15:14Z","updated_at":"2020-06-04T19:15:21Z"},{"id":181985,"account_id":1385,"registrant_id":null,"name":"example-beta.com","unicode_name":"example-beta.com","state":"hosted","auto_renew":false,"private_whois":false,"expires_on":null,"expires_at":null,"created_at":"2020-06-04T19:47:05Z","updated_at":"2020-06-04T19:47:05Z"}],"pagination":{"current_page":1,"per_page":30,"total_entries":2,"total_pages":1}}

--- a/src/test/resources/com/dnsimple/registerDomain/success.http
+++ b/src/test/resources/com/dnsimple/registerDomain/success.http
@@ -18,4 +18,4 @@ X-Permitted-Cross-Domain-Policies: none
 X-XSS-Protection: 1; mode=block
 Strict-Transport-Security: max-age=31536000
 
-{"data":{"id":1,"domain_id":999,"registrant_id":2,"period":1,"state":"new","auto_renew":false,"whois_privacy":false,"premium_price":null,"created_at":"2016-12-09T19:35:31Z","updated_at":"2016-12-09T19:35:31Z"}}
+{"data":{"id":1,"domain_id":999,"registrant_id":2,"period":1,"state":"new","auto_renew":false,"whois_privacy":false,"created_at":"2016-12-09T19:35:31Z","updated_at":"2016-12-09T19:35:31Z"}}

--- a/src/test/resources/com/dnsimple/renewDomain/success.http
+++ b/src/test/resources/com/dnsimple/renewDomain/success.http
@@ -18,4 +18,4 @@ X-Permitted-Cross-Domain-Policies: none
 X-XSS-Protection: 1; mode=block
 Strict-Transport-Security: max-age=31536000
 
-{"data":{"id":1,"domain_id":999,"period":1,"state":"new","premium_price":null,"created_at":"2016-12-09T19:46:45Z","updated_at":"2016-12-09T19:46:45Z"}}
+{"data":{"id":1,"domain_id":999,"period":1,"state":"new","created_at":"2016-12-09T19:46:45Z","updated_at":"2016-12-09T19:46:45Z"}}

--- a/src/test/resources/com/dnsimple/transferDomain/success.http
+++ b/src/test/resources/com/dnsimple/transferDomain/success.http
@@ -18,4 +18,4 @@ X-Permitted-Cross-Domain-Policies: none
 X-XSS-Protection: 1; mode=block
 Strict-Transport-Security: max-age=31536000
 
-{"data":{"id":1,"domain_id":999,"registrant_id":2,"state":"transferring","auto_renew":false,"whois_privacy":false,"premium_price":null,"created_at":"2016-12-09T19:43:41Z","updated_at":"2016-12-09T19:43:43Z"}}
+{"data":{"id":1,"domain_id":999,"registrant_id":2,"state":"transferring","auto_renew":false,"whois_privacy":false,"created_at":"2016-12-09T19:43:41Z","updated_at":"2016-12-09T19:43:43Z"}}


### PR DESCRIPTION
We deprecated expires on attribute in our documentation in favor of
expires at. This commit introduces the new field and deprecates the old
one. It also updates to use the new fixtures.