### PR TITLE
Replace `master` with `main`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-### master
+### main
 
 **Warning**: This release contains breaking changes. Please contact DNSimple if you need assistance migrating your project to this version of the Java API Client
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,11 +57,11 @@ This project uses [Semantic Versioning](https://semver.org/). The following inst
     ```groovy
     version = '<VERSION>'
     ```
-1. Finalize the `## master` section in `CHANGELOG.md` assigning the version.
+1. Finalize the `## main` section in `CHANGELOG.md` assigning the version.
 1. Commit and push the changes
     ```shell
     git commit -a -m "Release $VERSION"
-    git push origin master
+    git push origin main
     ```
 1. Wait for CI to complete.
 1. Create a signed tag.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Java client for the [DNSimple API v2](https://developer.dnsimple.com/v2/).
 
-[![Build Status](https://travis-ci.com/dnsimple/dnsimple-java.svg?branch=master)](https://travis-ci.com/dnsimple/dnsimple-java)
+[![Build Status](https://travis-ci.com/dnsimple/dnsimple-java.svg?branch=main)](https://travis-ci.com/dnsimple/dnsimple-java)
 
 
 ## Requirements


### PR DESCRIPTION
We have changed the default branch on this repo from `master` to `main`. This PR updates docs and instructions to reflect this change.