### PR TITLE
Task/74 endpoint action review

### DIFF
--- a/src/main/java/com/dnsimple/data/DomainPremiumPriceCheck.java
+++ b/src/main/java/com/dnsimple/data/DomainPremiumPriceCheck.java
@@ -1,0 +1,19 @@
+package com.dnsimple.data;
+
+public class DomainPremiumPriceCheck {
+    private final String premiumPrice;
+    private final String action;
+
+    public DomainPremiumPriceCheck(String premiumPrice, String action) {
+        this.premiumPrice = premiumPrice;
+        this.action = action;
+    }
+
+    public String getPremiumPrice() {
+        return premiumPrice;
+    }
+
+    public String getAction() {
+        return action;
+    }
+}

--- a/src/main/java/com/dnsimple/endpoints/Accounts.java
+++ b/src/main/java/com/dnsimple/endpoints/Accounts.java
@@ -23,7 +23,7 @@ public final class Accounts {
      * Lists the accounts the authenticated entity has access to.
      *
      * @return The list accounts response
-     * @see <a href="https://developer.dnsimple.com/v2/accounts#list">https://developer.dnsimple.com/v2/accounts#list</a>
+     * @see <a href="https://developer.dnsimple.com/v2/accounts#listAccounts">https://developer.dnsimple.com/v2/accounts#listAccounts</a>
      */
     public ListResponse<Account> listAccounts() {
         return client.list(GET, "accounts", ListOptions.empty(), null, Account.class);

--- a/src/main/java/com/dnsimple/endpoints/Contacts.java
+++ b/src/main/java/com/dnsimple/endpoints/Contacts.java
@@ -28,7 +28,7 @@ public class Contacts {
      *
      * @param account The account ID
      * @return The list contacts response
-     * @see <a href="https://developer.dnsimple.com/v2/contacts/#list">https://developer.dnsimple.com/v2/contacts/#list</a>
+     * @see <a href="https://developer.dnsimple.com/v2/contacts/#listContacts">https://developer.dnsimple.com/v2/contacts/#listContacts</a>
      */
     public PaginatedResponse<Contact> listContacts(Number account) {
         return client.page(GET, account + "/contacts", ListOptions.empty(), null, Contact.class);
@@ -40,22 +40,10 @@ public class Contacts {
      * @param account The account ID
      * @param options The options for the list request
      * @return The list contacts response
-     * @see <a href="https://developer.dnsimple.com/v2/contacts/#list">https://developer.dnsimple.com/v2/contacts/#list</a>
+     * @see <a href="https://developer.dnsimple.com/v2/contacts/#listContacts">https://developer.dnsimple.com/v2/contacts/#listContacts</a>
      */
     public PaginatedResponse<Contact> listContacts(Number account, ListOptions options) {
         return client.page(GET, account + "/contacts", options, null, Contact.class);
-    }
-
-    /**
-     * Get a specific contact associated to an account using the contacts's ID.
-     *
-     * @param account   The account ID
-     * @param contactId The contact ID
-     * @return The get contact response
-     * @see <a href="https://developer.dnsimple.com/v2/contacts/#get">https://developer.dnsimple.com/v2/contacts/#get</a>
-     */
-    public SimpleResponse<Contact> getContact(Number account, Number contactId) {
-        return client.simple(GET, account + "/contacts/" + contactId, ListOptions.empty(), emptyMap(), Contact.class);
     }
 
     /**
@@ -64,10 +52,22 @@ public class Contacts {
      * @param account The account ID
      * @param options options to create the new contact
      * @return The create contact response
-     * @see <a href="https://developer.dnsimple.com/v2/contacts/#create">https://developer.dnsimple.com/v2/contacts/#create</a>
+     * @see <a href="https://developer.dnsimple.com/v2/contacts/#createContact">https://developer.dnsimple.com/v2/contacts/#createContact</a>
      */
     public SimpleResponse<Contact> createContact(Number account, ContactOptions options) {
         return client.simple(POST, account + "/contacts", ListOptions.empty(), options, Contact.class);
+    }
+
+    /**
+     * Get a specific contact associated to an account using the contacts's ID.
+     *
+     * @param account   The account ID
+     * @param contactId The contact ID
+     * @return The get contact response
+     * @see <a href="https://developer.dnsimple.com/v2/contacts/#getContact">https://developer.dnsimple.com/v2/contacts/#getContact</a>
+     */
+    public SimpleResponse<Contact> getContact(Number account, Number contactId) {
+        return client.simple(GET, account + "/contacts/" + contactId, ListOptions.empty(), emptyMap(), Contact.class);
     }
 
     /**
@@ -77,7 +77,7 @@ public class Contacts {
      * @param contactId The contact ID
      * @param options   options to update the contact
      * @return The update contact response
-     * @see <a href="https://developer.dnsimple.com/v2/contacts/#update">https://developer.dnsimple.com/v2/contacts/#update</a>
+     * @see <a href="https://developer.dnsimple.com/v2/contacts/#updateContact">https://developer.dnsimple.com/v2/contacts/#updateContact</a>
      */
     public SimpleResponse<Contact> updateContact(Number account, Number contactId, ContactOptions options) {
         return client.simple(PATCH, account + "/contacts/" + contactId, ListOptions.empty(), options, Contact.class);
@@ -89,7 +89,7 @@ public class Contacts {
      * @param account   The account ID
      * @param contactId The contact ID
      * @return The delete contact response
-     * @see <a href="https://developer.dnsimple.com/v2/contacts/#delete">https://developer.dnsimple.com/v2/contacts/#delete</a>
+     * @see <a href="https://developer.dnsimple.com/v2/contacts/#deleteContact">https://developer.dnsimple.com/v2/contacts/#deleteContact</a>
      */
     public EmptyResponse deleteContact(Number account, Number contactId) {
         return client.empty(DELETE, account + "/contacts/" + contactId, ListOptions.empty(), null);

--- a/src/main/java/com/dnsimple/endpoints/Domains.java
+++ b/src/main/java/com/dnsimple/endpoints/Domains.java
@@ -31,7 +31,7 @@ public class Domains {
      *
      * @param account The account ID
      * @return The list domains response
-     * @see <a href="https://developer.dnsimple.com/v2/domains/#list">https://developer.dnsimple.com/v2/domains/#list</a>
+     * @see <a href="https://developer.dnsimple.com/v2/domains/#listDomains">https://developer.dnsimple.com/v2/domains/#listDomains</a>
      */
     public PaginatedResponse<Domain> listDomains(Number account) {
         return client.page(GET, account + "/domains", ListOptions.empty(), null, Domain.class);
@@ -43,22 +43,10 @@ public class Domains {
      * @param account The account ID
      * @param options The options for the list request
      * @return The list domains response
-     * @see <a href="https://developer.dnsimple.com/v2/domains/#list">https://developer.dnsimple.com/v2/domains/#list</a>
+     * @see <a href="https://developer.dnsimple.com/v2/domains/#listDomains">https://developer.dnsimple.com/v2/domains/#listDomains</a>
      */
     public PaginatedResponse<Domain> listDomains(Number account, ListOptions options) {
         return client.page(GET, account + "/domains", options, null, Domain.class);
-    }
-
-    /**
-     * Get a specific domain associated to an account using the domain's name or ID.
-     *
-     * @param account The account ID
-     * @param domain  The domain name or ID
-     * @return The get domain response
-     * @see <a href="https://developer.dnsimple.com/v2/domains/#get">https://developer.dnsimple.com/v2/domains/#get</a>
-     */
-    public SimpleResponse<Domain> getDomain(Number account, String domain) {
-        return client.simple(GET, account + "/domains/" + domain, ListOptions.empty(), null, Domain.class);
     }
 
     /**
@@ -67,10 +55,22 @@ public class Domains {
      * @param account The account ID
      * @param name    The name of the domain
      * @return The create domain response
-     * @see <a href="https://developer.dnsimple.com/v2/domains/#create">https://developer.dnsimple.com/v2/domains/#create</a>
+     * @see <a href="https://developer.dnsimple.com/v2/domains/#createDomain">https://developer.dnsimple.com/v2/domains/#createDomain</a>
      */
     public SimpleResponse<Domain> createDomain(Number account, String name) {
         return client.simple(POST, account + "/domains", ListOptions.empty(), singletonMap("name", name), Domain.class);
+    }
+
+    /**
+     * Get a specific domain associated to an account using the domain's name or ID.
+     *
+     * @param account The account ID
+     * @param domain  The domain name or ID
+     * @return The get domain response
+     * @see <a href="https://developer.dnsimple.com/v2/domains/#getDomain">https://developer.dnsimple.com/v2/domains/#getDomain</a>
+     */
+    public SimpleResponse<Domain> getDomain(Number account, String domain) {
+        return client.simple(GET, account + "/domains/" + domain, ListOptions.empty(), null, Domain.class);
     }
 
     /**
@@ -81,7 +81,7 @@ public class Domains {
      * @param account The account ID
      * @param domain  The domain ID or name or name
      * @return The delete domain response
-     * @see <a href="https://developer.dnsimple.com/v2/domains/#delete">https://developer.dnsimple.com/v2/domains/#delete</a>
+     * @see <a href="https://developer.dnsimple.com/v2/domains/#deleteDomain">https://developer.dnsimple.com/v2/domains/#deleteDomain</a>
      */
     public EmptyResponse deleteDomain(Number account, String domain) {
         return client.empty(DELETE, account + "/domains/" + domain, ListOptions.empty(), null);
@@ -106,7 +106,7 @@ public class Domains {
      * @param domain  The domain ID or name
      * @param options The options for the list request
      * @return The list collaborators response
-     * @see <a href="https://developer.dnsimple.com/v2/domains/collaborators/#list">https://developer.dnsimple.com/v2/domains/collaborators/#list</a>
+     * @see <a href="https://developer.dnsimple.com/v2/domains/collaborators/#listCollaborators">https://developer.dnsimple.com/v2/domains/collaborators/#listCollaborators</a>
      */
     public PaginatedResponse<Collaborator> listCollaborators(Number account, String domain, ListOptions options) {
         return client.page(GET, account + "/domains/" + domain + "/collaborators", options, null, Collaborator.class);
@@ -119,7 +119,7 @@ public class Domains {
      * @param domain  The domain ID or name
      * @param email   The email of the collaborator
      * @return The add collaborator response
-     * @see <a href="https://developer.dnsimple.com/v2/domains/collaborators/#add">https://developer.dnsimple.com/v2/domains/collaborators/#create</a>
+     * @see <a href="https://developer.dnsimple.com/v2/domains/collaborators/#addCollaborator">https://developer.dnsimple.com/v2/domains/collaborators/#addCollaborator</a>
      */
     public SimpleResponse<Collaborator> addCollaborator(Number account, String domain, String email) {
         return client.simple(POST, account + "/domains/" + domain + "/collaborators", ListOptions.empty(), singletonMap("email", email), Collaborator.class);
@@ -132,7 +132,7 @@ public class Domains {
      * @param domain         The domain ID or name
      * @param collaboratorId The collaborator ID
      * @return The remove collaborator response
-     * @see <a href="https://developer.dnsimple.com/v2/domains/collaborators/#remove">https://developer.dnsimple.com/v2/domains/collaborators/#remove</a>
+     * @see <a href="https://developer.dnsimple.com/v2/domains/collaborators/#removeCollaborator">https://developer.dnsimple.com/v2/domains/collaborators/#removeCollaborator</a>
      */
     public EmptyResponse removeCollaborator(Number account, String domain, String collaboratorId) {
         return client.empty(DELETE, account + "/domains/" + domain + "/collaborators/" + collaboratorId, ListOptions.empty(), null);
@@ -144,7 +144,7 @@ public class Domains {
      * @param account The account ID
      * @param domain  The domain ID or name or name
      * @return The DNSSEC enable response
-     * @see <a href="https://developer.dnsimple.com/v2/domains/dnssec/#enable">https://developer.dnsimple.com/v2/domains/dnssec/#enable</a>
+     * @see <a href="https://developer.dnsimple.com/v2/domains/dnssec/#enableDomainDnssec">https://developer.dnsimple.com/v2/domains/dnssec/#enableDomainDnssec</a>
      */
     public SimpleResponse<Dnssec> enableDnssec(Number account, String domain) {
         return client.simple(POST, account + "/domains/" + domain + "/dnssec", ListOptions.empty(), null, Dnssec.class);
@@ -156,7 +156,7 @@ public class Domains {
      * @param account The account ID
      * @param domain  The domain ID or name or name
      * @return The DNSSEC disable response
-     * @see <a href="https://developer.dnsimple.com/v2/domains/dnssec/#disable">https://developer.dnsimple.com/v2/domains/dnssec/#disable</a>
+     * @see <a href="https://developer.dnsimple.com/v2/domains/dnssec/#disableDomainDnsec">https://developer.dnsimple.com/v2/domains/dnssec/#disableDomainDnsec</a>
      */
     public EmptyResponse disableDnssec(Number account, String domain) {
         return client.empty(DELETE, account + "/domains/" + domain + "/dnssec", ListOptions.empty(), null);
@@ -168,7 +168,7 @@ public class Domains {
      * @param account The account ID
      * @param domain  The domain ID or name or name
      * @return The get DNSSEC response
-     * @see <a href="https://developer.dnsimple.com/v2/domains/dnssec/#get">https://developer.dnsimple.com/v2/domains/dnssec/#get</a>
+     * @see <a href="https://developer.dnsimple.com/v2/domains/dnssec/#getDomainDnssec">https://developer.dnsimple.com/v2/domains/dnssec/#getDomainDnssec</a>
      */
     public SimpleResponse<Dnssec> getDnssec(Number account, String domain) {
         return client.simple(GET, account + "/domains/" + domain + "/dnssec", ListOptions.empty(), null, Dnssec.class);
@@ -180,7 +180,7 @@ public class Domains {
      * @param account The account ID
      * @param domain  The domain ID or name or name
      * @return The list delegation signer records response
-     * @see <a href="https://developer.dnsimple.com/v2/domains/dnssec/#ds-record-list">https://developer.dnsimple.com/v2/domains/dnssec/#ds-record-list</a>
+     * @see <a href="https://developer.dnsimple.com/v2/domains/dnssec/#listDomainDelegationSignerRecords">https://developer.dnsimple.com/v2/domains/dnssec/#listDomainDelegationSignerRecords</a>
      */
     public PaginatedResponse<DelegationSignerRecord> listDelegationSignerRecords(Number account, String domain) {
         return client.page(GET, account + "/domains/" + domain + "/ds_records", ListOptions.empty(), null, DelegationSignerRecord.class);
@@ -193,23 +193,10 @@ public class Domains {
      * @param domain  The domain ID or name or name
      * @param options The options for the list request
      * @return The list delegation signer records response
-     * @see <a href="https://developer.dnsimple.com/v2/domains/dnssec/#ds-record-list">https://developer.dnsimple.com/v2/domains/dnssec/#ds-record-list</a>
+     * @see <a href="https://developer.dnsimple.com/v2/domains/dnssec/#listDomainDelegationSignerRecords">https://developer.dnsimple.com/v2/domains/dnssec/#listDomainDelegationSignerRecords</a>
      */
     public PaginatedResponse<DelegationSignerRecord> listDelegationSignerRecords(Number account, String domain, ListOptions options) {
         return client.page(GET, account + "/domains/" + domain + "/ds_records", options, null, DelegationSignerRecord.class);
-    }
-
-    /**
-     * Get a delegation signer record for a domain using the delegation signer records's ID.
-     *
-     * @param account    The account ID
-     * @param domain     The domain name or ID
-     * @param dsRecordId The delegation signer record ID
-     * @return The get delegation signer record response
-     * @see <a href="https://developer.dnsimple.com/v2/domains/dnssec/#ds-record-get">https://developer.dnsimple.com/v2/domains/dnssec/#ds-record-get</a>
-     */
-    public SimpleResponse<DelegationSignerRecord> getDelegationSignerRecord(Number account, String domain, Number dsRecordId) {
-        return client.simple(GET, account + "/domains/" + domain + "/ds_records/" + dsRecordId, ListOptions.empty(), null, DelegationSignerRecord.class);
     }
 
     /**
@@ -219,10 +206,23 @@ public class Domains {
      * @param domain  The domain name or ID
      * @param options The options to create the DS record
      * @return The create delegation signer record response
-     * @see <a href="https://developer.dnsimple.com/v2/domains/dnssec/#ds-record-create">https://developer.dnsimple.com/v2/domains/dnssec/#ds-record-create</a>
+     * @see <a href="https://developer.dnsimple.com/v2/domains/dnssec/#createDomainDelegationSignerRecord">https://developer.dnsimple.com/v2/domains/dnssec/#createDomainDelegationSignerRecord</a>
      */
     public SimpleResponse<DelegationSignerRecord> createDelegationSignerRecord(Number account, String domain, DSRecordOptions options) {
         return client.simple(POST, account + "/domains/" + domain + "/ds_records", ListOptions.empty(), options, DelegationSignerRecord.class);
+    }
+
+    /**
+     * Get a delegation signer record for a domain using the delegation signer records's ID.
+     *
+     * @param account    The account ID
+     * @param domain     The domain name or ID
+     * @param dsRecordId The delegation signer record ID
+     * @return The get delegation signer record response
+     * @see <a href="https://developer.dnsimple.com/v2/domains/dnssec/#getDomainDelegationSignerRecord">https://developer.dnsimple.com/v2/domains/dnssec/#getDomainDelegationSignerRecord</a>
+     */
+    public SimpleResponse<DelegationSignerRecord> getDelegationSignerRecord(Number account, String domain, Number dsRecordId) {
+        return client.simple(GET, account + "/domains/" + domain + "/ds_records/" + dsRecordId, ListOptions.empty(), null, DelegationSignerRecord.class);
     }
 
     /**
@@ -234,7 +234,7 @@ public class Domains {
      * @param domain     The domain ID or name or name
      * @param dsRecordId The delegation signer record ID
      * @return The delete delegation signer record response
-     * @see <a href="https://developer.dnsimple.com/v2/domains/dnssec/#ds-record-delete">https://developer.dnsimple.com/v2/domains/dnssec/#ds-record-delete</a>
+     * @see <a href="https://developer.dnsimple.com/v2/domains/dnssec/#deleteDomainDelegationSignerRecord">https://developer.dnsimple.com/v2/domains/dnssec/#deleteDomainDelegationSignerRecord</a>
      */
     public EmptyResponse deleteDelegationSignerRecord(Number account, String domain, Number dsRecordId) {
         return client.empty(DELETE, account + "/domains/" + domain + "/ds_records/" + dsRecordId, ListOptions.empty(), null);
@@ -246,7 +246,7 @@ public class Domains {
      * @param account The account ID
      * @param domain  The domain ID or name or name
      * @return The list email forwards response
-     * @see <a href="https://developer.dnsimple.com/v2/domains/email-forwards/#list">https://developer.dnsimple.com/v2/domains/email-forwards/#list</a>
+     * @see <a href="https://developer.dnsimple.com/v2/domains/email-forwards/#listEmailForwards">https://developer.dnsimple.com/v2/domains/email-forwards/#listEmailForwards</a>
      */
     public PaginatedResponse<EmailForward> listEmailForwards(Number account, String domain) {
         return client.page(GET, account + "/domains/" + domain + "/email_forwards", ListOptions.empty(), null, EmailForward.class);
@@ -259,23 +259,10 @@ public class Domains {
      * @param domain  The domain ID or name or name
      * @param options The options for the list request
      * @return The list email forwards response
-     * @see <a href="https://developer.dnsimple.com/v2/domains/email-forwards/#list">https://developer.dnsimple.com/v2/domains/email-forwards/#list</a>
+     * @see <a href="https://developer.dnsimple.com/v2/domains/email-forwards/#listEmailForwards">https://developer.dnsimple.com/v2/domains/email-forwards/#listEmailForwards</a>
      */
     public PaginatedResponse<EmailForward> listEmailForwards(Number account, String domain, ListOptions options) {
         return client.page(GET, account + "/domains/" + domain + "/email_forwards", options, null, EmailForward.class);
-    }
-
-    /**
-     * Get a specific email forward associated to a domain using the email forward's ID.
-     *
-     * @param account      The account ID
-     * @param domain       The domain name or ID
-     * @param emailForward The email forward ID
-     * @return The get email forward response
-     * @see <a href="https://developer.dnsimple.com/v2/domains/email-forwards/#get">https://developer.dnsimple.com/v2/domains/email-forwards/#get</a>
-     */
-    public SimpleResponse<EmailForward> getEmailForward(Number account, String domain, Number emailForward) {
-        return client.simple(GET, account + "/domains/" + domain + "/email_forwards/" + emailForward, ListOptions.empty(), null, EmailForward.class);
     }
 
     /**
@@ -286,13 +273,26 @@ public class Domains {
      * @param from    The email address the emails are send to
      * @param to      The email address the email address the emails are forwarded to.
      * @return The create email forward response
-     * @see <a href="https://developer.dnsimple.com/v2/domains/email-forwards/#create">https://developer.dnsimple.com/v2/domains/email-forwards/#create</a>
+     * @see <a href="https://developer.dnsimple.com/v2/domains/email-forwards/#createEmailForward">https://developer.dnsimple.com/v2/domains/email-forwards/#createEmailForward</a>
      */
     public SimpleResponse<EmailForward> createEmailForward(Number account, String domain, String from, String to) {
         Map<String, String> options = new HashMap<>();
         options.put("from", from);
         options.put("to", to);
         return client.simple(POST, account + "/domains/" + domain + "/email_forwards", ListOptions.empty(), options, EmailForward.class);
+    }
+
+    /**
+     * Get a specific email forward associated to a domain using the email forward's ID.
+     *
+     * @param account      The account ID
+     * @param domain       The domain name or ID
+     * @param emailForward The email forward ID
+     * @return The get email forward response
+     * @see <a href="https://developer.dnsimple.com/v2/domains/email-forwards/#getEmailForward">https://developer.dnsimple.com/v2/domains/email-forwards/#getEmailForward</a>
+     */
+    public SimpleResponse<EmailForward> getEmailForward(Number account, String domain, Number emailForward) {
+        return client.simple(GET, account + "/domains/" + domain + "/email_forwards/" + emailForward, ListOptions.empty(), null, EmailForward.class);
     }
 
     /**
@@ -304,7 +304,7 @@ public class Domains {
      * @param domain       The domain ID or name or name
      * @param emailForward The email forward ID
      * @return The delete email forward response
-     * @see <a href="https://developer.dnsimple.com/v2/domains/email-forwards/#delete">https://developer.dnsimple.com/v2/domains/email-forwards/#delete</a>
+     * @see <a href="https://developer.dnsimple.com/v2/domains/email-forwards/#deleteEmailForward">https://developer.dnsimple.com/v2/domains/email-forwards/#deleteEmailForward</a>
      */
     public EmptyResponse deleteEmailForward(Number account, String domain, Number emailForward) {
         return client.empty(DELETE, account + "/domains/" + domain + "/email_forwards/" + emailForward, ListOptions.empty(), null);
@@ -317,7 +317,7 @@ public class Domains {
      * @param domain          The domain name or ID
      * @param newAccountEmail The email address of the target DNSimple account
      * @return The initiate push response
-     * @see <a href="https://developer.dnsimple.com/v2/domains/pushes/#initiate">https://developer.dnsimple.com/v2/domains/pushes/#initiate</a>
+     * @see <a href="https://developer.dnsimple.com/v2/domains/pushes/#initiateDomainPush">https://developer.dnsimple.com/v2/domains/pushes/#initiateDomainPush</a>
      */
     public SimpleResponse<DomainPush> initiatePush(Number account, String domain, String newAccountEmail) {
         return client.simple(POST, account + "/domains/" + domain + "/pushes", ListOptions.empty(), singletonMap("new_account_email", newAccountEmail), DomainPush.class);
@@ -329,7 +329,7 @@ public class Domains {
      * @param account The account ID
      * @param domain  The domain ID or name or name
      * @return The list pushes response
-     * @see <a href="https://developer.dnsimple.com/v2/domains/pushes/#list">https://developer.dnsimple.com/v2/domains/pushes/#list</a>
+     * @see <a href="https://developer.dnsimple.com/v2/domains/pushes/#listPushes">https://developer.dnsimple.com/v2/domains/pushes/#listPushes</a>
      */
     public PaginatedResponse<DomainPush> listPushes(Number account, String domain) {
         return client.page(GET, account + "/domains/" + domain + "/pushes", ListOptions.empty(), null, DomainPush.class);
@@ -342,7 +342,7 @@ public class Domains {
      * @param domain  The domain ID or name or name
      * @param options The options for the list request
      * @return The list pushes response
-     * @see <a href="https://developer.dnsimple.com/v2/domains/pushes/#list">https://developer.dnsimple.com/v2/domains/pushes/#list</a>
+     * @see <a href="https://developer.dnsimple.com/v2/domains/pushes/#listPushes">https://developer.dnsimple.com/v2/domains/pushes/#listPushes</a>
      */
     public PaginatedResponse<DomainPush> listPushes(Number account, String domain, ListOptions options) {
         return client.page(GET, account + "/domains/" + domain + "/pushes", options, null, DomainPush.class);
@@ -355,7 +355,7 @@ public class Domains {
      * @param push      The push ID
      * @param contactId A contact that belongs to the target DNSimple account
      * @return The accept push response
-     * @see <a href="https://developer.dnsimple.com/v2/domains/pushes/#accept">https://developer.dnsimple.com/v2/domains/pushes/#accept</a>
+     * @see <a href="https://developer.dnsimple.com/v2/domains/pushes/#acceptPush">https://developer.dnsimple.com/v2/domains/pushes/#acceptPush</a>
      */
     public EmptyResponse acceptPush(Number account, Number push, Number contactId) {
         return client.empty(POST, account + "/pushes/" + push, ListOptions.empty(), singletonMap("contact_id", contactId.longValue()));
@@ -367,7 +367,7 @@ public class Domains {
      * @param account The account ID
      * @param push    The push ID
      * @return The accept push response
-     * @see <a href="https://developer.dnsimple.com/v2/domains/pushes/#reject">https://developer.dnsimple.com/v2/domains/pushes/#reject</a>
+     * @see <a href="https://developer.dnsimple.com/v2/domains/pushes/#rejectPush">https://developer.dnsimple.com/v2/domains/pushes/#rejectPush</a>
      */
     public EmptyResponse rejectPush(Number account, Number push) {
         return client.empty(DELETE, account + "/pushes/" + push, ListOptions.empty(), null);

--- a/src/main/java/com/dnsimple/endpoints/Domains.java
+++ b/src/main/java/com/dnsimple/endpoints/Domains.java
@@ -88,18 +88,6 @@ public class Domains {
     }
 
     /**
-     * Resets the domain token.
-     *
-     * @param account The account ID
-     * @param domain  The domain ID or name or name
-     * @return The reset token domain response
-     * @see <a href="https://developer.dnsimple.com/v2/domains/#reset-token">https://developer.dnsimple.com/v2/domains/#reset-token</a>
-     */
-    public SimpleResponse<Domain> resetDomainToken(Number account, String domain) {
-        return client.simple(POST, account + "/domains/" + domain, ListOptions.empty(), null, Domain.class);
-    }
-
-    /**
      * Lists the collaborators in the domain.
      *
      * @param account The account ID

--- a/src/main/java/com/dnsimple/endpoints/Registrar.java
+++ b/src/main/java/com/dnsimple/endpoints/Registrar.java
@@ -29,7 +29,7 @@ public class Registrar {
      * @param account    The account ID
      * @param domainName The domain to check
      * @return The check domain response
-     * @see <a href="https://developer.dnsimple.com/v2/registrar/#check">https://developer.dnsimple.com/v2/registrar/#check</a>
+     * @see <a href="https://developer.dnsimple.com/v2/registrar/#checkDomain">https://developer.dnsimple.com/v2/registrar/#checkDomain</a>
      */
     public SimpleResponse<DomainCheck> checkDomain(Number account, String domainName) {
         return client.simple(GET, account + "/registrar/domains/" + domainName + "/check", ListOptions.empty(), null, DomainCheck.class);
@@ -44,7 +44,7 @@ public class Registrar {
      * @return The premium price
      * @see <a href="https://developer.dnsimple.com/v2/registrar/#getDomainPremiumPrice">https://developer.dnsimple.com/v2/registrar/#getDomainPremiumPrice</a>
      */
-    public SimpleResponse<DomainPremiumPriceCheck> checkDomainPremiumPrice(Number account, String domainName, DomainCheckPremiumPriceAction action) {
+    public SimpleResponse<DomainPremiumPriceCheck> getDomainPremiumPrice(Number account, String domainName, DomainCheckPremiumPriceAction action) {
         var options = ListOptions.empty().filter("action", action.name().toLowerCase());
         return client.simple(GET, account + "/registrar/domains/" + domainName + "/premium_price", options, action, DomainPremiumPriceCheck.class);
     }
@@ -56,23 +56,10 @@ public class Registrar {
      * @param domainName The domain to register
      * @param options    The options for the domain registration
      * @return The register domain response
-     * @see <a href="https://developer.dnsimple.com/v2/registrar/#register">https://developer.dnsimple.com/v2/registrar/#register</a>
+     * @see <a href="https://developer.dnsimple.com/v2/registrar/#registerDomain">https://developer.dnsimple.com/v2/registrar/#registerDomain</a>
      */
     public SimpleResponse<DomainRegistration> registerDomain(Number account, String domainName, RegistrationOptions options) {
         return client.simple(POST, account + "/registrar/domains/" + domainName + "/registrations", ListOptions.empty(), options, DomainRegistration.class);
-    }
-
-    /**
-     * Renews a domain.
-     *
-     * @param account The account ID
-     * @param domain  The domain name or ID
-     * @param options The options for the renewal
-     * @return The renew domain response
-     * @see <a href="https://developer.dnsimple.com/v2/registrar/#renew">https://developer.dnsimple.com/v2/registrar/#renew</a>
-     */
-    public SimpleResponse<DomainRenewal> renewDomain(Number account, String domain, RenewOptions options) {
-        return client.simple(POST, account + "/registrar/domains/" + domain + "/renewals", ListOptions.empty(), options, DomainRenewal.class);
     }
 
     /**
@@ -82,7 +69,7 @@ public class Registrar {
      * @param domain  The domain name or ID
      * @param options The options for the transfer
      * @return The transfer domain response
-     * @see <a href="https://developer.dnsimple.com/v2/registrar/#transfer">https://developer.dnsimple.com/v2/registrar/#transfer</a>
+     * @see <a href="https://developer.dnsimple.com/v2/registrar/#transferDomain">https://developer.dnsimple.com/v2/registrar/#transferDomain</a>
      */
     public SimpleResponse<DomainTransfer> transferDomain(Number account, String domain, TransferOptions options) {
         return client.simple(POST, account + "/registrar/domains/" + domain + "/transfers", ListOptions.empty(), options, DomainTransfer.class);
@@ -115,14 +102,27 @@ public class Registrar {
     }
 
     /**
-     * Requests the transfer of a domain out of DNSimple.
+     * Renews a domain.
+     *
+     * @param account The account ID
+     * @param domain  The domain name or ID
+     * @param options The options for the renewal
+     * @return The renew domain response
+     * @see <a href="https://developer.dnsimple.com/v2/registrar/#renewDomain">https://developer.dnsimple.com/v2/registrar/#renewDomain</a>
+     */
+    public SimpleResponse<DomainRenewal> renewDomain(Number account, String domain, RenewOptions options) {
+        return client.simple(POST, account + "/registrar/domains/" + domain + "/renewals", ListOptions.empty(), options, DomainRenewal.class);
+    }
+
+    /**
+     * Authorizes the transfer of a domain out of DNSimple.
      *
      * @param account The account ID
      * @param domain  The domain name or ID
      * @return The transfer domain out response
-     * @see <a href="https://developer.dnsimple.com/v2/registrar/#transfer-out">https://developer.dnsimple.com/v2/registrar/#transfer-out</a>
+     * @see <a href="https://developer.dnsimple.com/v2/registrar/#authorizeDomainTransferOut">https://developer.dnsimple.com/v2/registrar/#authorizeDomainTransferOut</a>
      */
-    public EmptyResponse transferDomainOut(Number account, String domain) {
+    public EmptyResponse authorizeTransferOut(Number account, String domain) {
         return client.empty(POST, account + "/registrar/domains/" + domain + "/authorize_transfer_out", ListOptions.empty(), null);
     }
 
@@ -156,7 +156,7 @@ public class Registrar {
      * @param account The account ID
      * @param domain  The domain name or ID
      * @return The get whois privacy response
-     * @see <a href="https://developer.dnsimple.com/v2/registrar/whois-privacy/#get">https://developer.dnsimple.com/v2/registrar/whois-privacy/#get</a>
+     * @see <a href="https://developer.dnsimple.com/v2/registrar/whois-privacy/#getWhoisPrivacy">https://developer.dnsimple.com/v2/registrar/whois-privacy/#getWhoisPrivacy</a>
      */
     public SimpleResponse<WhoisPrivacy> getWhoisPrivacy(Number account, String domain) {
         return client.simple(GET, account + "/registrar/domains/" + domain + "/whois_privacy", ListOptions.empty(), null, WhoisPrivacy.class);
@@ -168,7 +168,7 @@ public class Registrar {
      * @param account The account ID
      * @param domain  The domain name or ID
      * @return The enable whois privacy response
-     * @see <a href="https://developer.dnsimple.com/v2/registrar/whois-privacy/#enable">https://developer.dnsimple.com/v2/registrar/whois-privacy/#enable</a>
+     * @see <a href="https://developer.dnsimple.com/v2/registrar/whois-privacy/#enableWhoisPrivacy">https://developer.dnsimple.com/v2/registrar/whois-privacy/#enableWhoisPrivacy</a>
      */
     public SimpleResponse<WhoisPrivacy> enableWhoisPrivacy(Number account, String domain) {
         return client.simple(PUT, account + "/registrar/domains/" + domain + "/whois_privacy", ListOptions.empty(), null, WhoisPrivacy.class);
@@ -180,7 +180,7 @@ public class Registrar {
      * @param account The account ID
      * @param domain  The domain name or ID
      * @return The disable whois privacy response
-     * @see <a href="https://developer.dnsimple.com/v2/registrar/whois-privacy/#disable">https://developer.dnsimple.com/v2/registrar/whois-privacy/#disable</a>
+     * @see <a href="https://developer.dnsimple.com/v2/registrar/whois-privacy/#disableWhoisPrivacy">https://developer.dnsimple.com/v2/registrar/whois-privacy/#disableWhoisPrivacy</a>
      */
     public SimpleResponse<WhoisPrivacy> disableWhoisPrivacy(Number account, String domain) {
         return client.simple(DELETE, account + "/registrar/domains/" + domain + "/whois_privacy", ListOptions.empty(), null, WhoisPrivacy.class);
@@ -192,7 +192,7 @@ public class Registrar {
      * @param account The account ID
      * @param domain  The domain name or ID
      * @return The disable whois privacy response
-     * @see <a href="https://developer.dnsimple.com/v2/registrar/whois-privacy/#renew">https://developer.dnsimple.com/v2/registrar/whois-privacy/#renew</a>
+     * @see <a href="https://developer.dnsimple.com/v2/registrar/whois-privacy/#renewWhoisPrivacy">https://developer.dnsimple.com/v2/registrar/whois-privacy/#renewWhoisPrivacy</a>
      */
     public SimpleResponse<WhoisPrivacyRenewal> renewWhoisPrivacy(Number account, String domain) {
         return client.simple(POST, account + "/registrar/domains/" + domain + "/whois_privacy/renewals", ListOptions.empty(), null, WhoisPrivacyRenewal.class);
@@ -204,7 +204,7 @@ public class Registrar {
      * @param account The account ID
      * @param domain  The domain name or ID
      * @return The get domain delegation response
-     * @see <a href="https://developer.dnsimple.com/v2/registrar/delegation/#list">https://developer.dnsimple.com/v2/registrar/delegation/#list</a>
+     * @see <a href="https://developer.dnsimple.com/v2/registrar/delegation/#getDomainDelegation">https://developer.dnsimple.com/v2/registrar/delegation/#getDomainDelegation</a>
      */
     public ListResponse<String> getDomainDelegation(Number account, String domain) {
         return client.list(GET, account + "/registrar/domains/" + domain + "/delegation", ListOptions.empty(), null, String.class);
@@ -217,7 +217,7 @@ public class Registrar {
      * @param domain          The domain ID or name
      * @param nameServerNames The name server names to change the delegation to
      * @return The change domain delegation response
-     * @see <a href="https://developer.dnsimple.com/v2/registrar/delegation/#update">https://developer.dnsimple.com/v2/registrar/delegation/#update</a>
+     * @see <a href="https://developer.dnsimple.com/v2/registrar/delegation/#changeDomainDelegation">https://developer.dnsimple.com/v2/registrar/delegation/#changeDomainDelegation</a>
      */
     public ListResponse<String> changeDomainDelegation(Number account, String domain, List<String> nameServerNames) {
         return client.list(PUT, account + "/registrar/domains/" + domain + "/delegation", ListOptions.empty(), nameServerNames, String.class);
@@ -230,7 +230,7 @@ public class Registrar {
      * @param domain          The domain ID or name
      * @param nameServerNames The vanity name server names
      * @return The change domain delegation to vanity response
-     * @see <a href="https://developer.dnsimple.com/v2/registrar/delegation/#delegateToVanity">https://developer.dnsimple.com/v2/registrar/delegation/#delegateToVanity</a>
+     * @see <a href="https://developer.dnsimple.com/v2/registrar/delegation/#changeDomainDelegationToVanity">https://developer.dnsimple.com/v2/registrar/delegation/#changeDomainDelegationToVanity</a>
      */
     public ListResponse<VanityNameServer> changeDomainDelegationToVanity(Number account, String domain, List<String> nameServerNames) {
         return client.list(PUT, account + "/registrar/domains/" + domain + "/delegation/vanity", ListOptions.empty(), nameServerNames, VanityNameServer.class);
@@ -242,7 +242,7 @@ public class Registrar {
      * @param account The account ID
      * @param domain  The domain ID or name
      * @return The change domain delegation from vanity response
-     * @see <a href="https://developer.dnsimple.com/v2/registrar/delegation/#delegateFromVanity">https://developer.dnsimple.com/v2/registrar/delegation/#delegateFromVanity</a>
+     * @see <a href="https://developer.dnsimple.com/v2/registrar/delegation/#changeDomainDelegationFromVanity">https://developer.dnsimple.com/v2/registrar/delegation/#changeDomainDelegationFromVanity</a>
      */
     public EmptyResponse changeDomainDelegationFromVanity(Number account, String domain) {
         return client.empty(DELETE, account + "/registrar/domains/" + domain + "/delegation/vanity", ListOptions.empty(), null);

--- a/src/main/java/com/dnsimple/endpoints/Registrar.java
+++ b/src/main/java/com/dnsimple/endpoints/Registrar.java
@@ -2,10 +2,7 @@ package com.dnsimple.endpoints;
 
 import com.dnsimple.data.*;
 import com.dnsimple.http.HttpEndpointClient;
-import com.dnsimple.request.ListOptions;
-import com.dnsimple.request.RegistrationOptions;
-import com.dnsimple.request.RenewOptions;
-import com.dnsimple.request.TransferOptions;
+import com.dnsimple.request.*;
 import com.dnsimple.response.EmptyResponse;
 import com.dnsimple.response.ListResponse;
 import com.dnsimple.response.SimpleResponse;
@@ -36,6 +33,20 @@ public class Registrar {
      */
     public SimpleResponse<DomainCheck> checkDomain(Number account, String domainName) {
         return client.simple(GET, account + "/registrar/domains/" + domainName + "/check", ListOptions.empty(), null, DomainCheck.class);
+    }
+
+    /**
+     * Checks the premium price of a domain for the provided action.
+     *
+     * @param account    The account ID
+     * @param domainName The domain to check
+     * @param action     The action to get the price of
+     * @return The premium price
+     * @see <a href="https://developer.dnsimple.com/v2/registrar/#getDomainPremiumPrice">https://developer.dnsimple.com/v2/registrar/#getDomainPremiumPrice</a>
+     */
+    public SimpleResponse<DomainPremiumPriceCheck> checkDomainPremiumPrice(Number account, String domainName, DomainCheckPremiumPriceAction action) {
+        var options = ListOptions.empty().filter("action", action.name().toLowerCase());
+        return client.simple(GET, account + "/registrar/domains/" + domainName + "/premium_price", options, action, DomainPremiumPriceCheck.class);
     }
 
     /**

--- a/src/main/java/com/dnsimple/endpoints/Services.java
+++ b/src/main/java/com/dnsimple/endpoints/Services.java
@@ -39,7 +39,7 @@ public class Services {
      *
      * @param options The options for the list request
      * @return The list services response
-     * @see <a href="https://developer.dnsimple.com/v2/services/#list">https://developer.dnsimple.com/v2/services/#list</a>
+     * @see <a href="https://developer.dnsimple.com/v2/services/#listServices">https://developer.dnsimple.com/v2/services/#listServices</a>
      */
     public ListResponse<Service> listServices(ListOptions options) {
         return client.list(GET, "services", options, null, Service.class);
@@ -50,7 +50,7 @@ public class Services {
      *
      * @param service The service name or ID
      * @return The get service response
-     * @see <a href="https://developer.dnsimple.com/v2/services/#get">https://developer.dnsimple.com/v2/services/#get</a>
+     * @see <a href="https://developer.dnsimple.com/v2/services/#getService">https://developer.dnsimple.com/v2/services/#getService</a>
      */
     public SimpleResponse<Service> getService(String service) {
         return client.simple(GET, "services/" + service, ListOptions.empty(), null, Service.class);
@@ -62,7 +62,7 @@ public class Services {
      * @param account The account ID
      * @param domain  The domain name or ID
      * @return The applied services response
-     * @see <a href="https://developer.dnsimple.com/v2/services/domains/#applied">https://developer.dnsimple.com/v2/services/domains/#applied</a>
+     * @see <a href="https://developer.dnsimple.com/v2/services/domains/#listDomainAppliedServices">https://developer.dnsimple.com/v2/services/domains/#listDomainAppliedServices</a>
      */
     public PaginatedResponse<Service> appliedServices(Number account, String domain) {
         return client.page(GET, account + "/domains/" + domain + "/services", ListOptions.empty(), null, Service.class);
@@ -75,7 +75,7 @@ public class Services {
      * @param domain  The domain name or ID
      * @param options The options for the list request
      * @return The applied services response
-     * @see <a href="https://developer.dnsimple.com/v2/services/domains/#applied">https://developer.dnsimple.com/v2/services/domains/#applied</a>
+     * @see <a href="https://developer.dnsimple.com/v2/services/domains/#listDomainAppliedServices">https://developer.dnsimple.com/v2/services/domains/#listDomainAppliedServices</a>
      */
     public PaginatedResponse<Service> appliedServices(Number account, String domain, ListOptions options) {
         return client.page(GET, account + "/domains/" + domain + "/services", options, null, Service.class);
@@ -89,7 +89,7 @@ public class Services {
      * @param service  The service name or ID to apply
      * @param settings A Map of settings for the service
      * @return The apply service response
-     * @see <a href="https://developer.dnsimple.com/v2/services/domains/#apply">https://developer.dnsimple.com/v2/services/domains/#apply</a>
+     * @see <a href="https://developer.dnsimple.com/v2/services/domains/#applyServiceToDomain">https://developer.dnsimple.com/v2/services/domains/#applyServiceToDomain</a>
      */
     public SimpleResponse<Service> applyService(Number account, String domain, String service, Map<String, Object> settings) {
         return client.simple(POST, account + "/domains/" + domain + "/services/" + service, ListOptions.empty(), singletonMap("settings", settings), Service.class);
@@ -102,7 +102,7 @@ public class Services {
      * @param domain  The domain name or ID
      * @param service The service name or ID to unapply
      * @return The unapply service response
-     * @see <a href="https://developer.dnsimple.com/v2/services/domains/#apply">https://developer.dnsimple.com/v2/services/domains/#apply</a>
+     * @see <a href="https://developer.dnsimple.com/v2/services/domains/#unapplyServiceFromDomain">https://developer.dnsimple.com/v2/services/domains/#unapplyServiceFromDomain</a>
      */
     public SimpleResponse<Service> unapplyService(Number account, String domain, String service) {
         return client.simple(DELETE, account + "/domains/" + domain + "/services/" + service, ListOptions.empty(), null, Service.class);

--- a/src/main/java/com/dnsimple/endpoints/Templates.java
+++ b/src/main/java/com/dnsimple/endpoints/Templates.java
@@ -29,7 +29,7 @@ public class Templates {
      *
      * @param account The account ID
      * @return The list templates response
-     * @see <a href="https://developer.dnsimple.com/v2/templates/#list">https://developer.dnsimple.com/v2/templates/#list</a>
+     * @see <a href="https://developer.dnsimple.com/v2/templates/#listTemplates">https://developer.dnsimple.com/v2/templates/#listTemplates</a>
      */
     public PaginatedResponse<Template> listTemplates(Number account) {
         return client.page(GET, account + "/templates", ListOptions.empty(), null, Template.class);
@@ -41,22 +41,10 @@ public class Templates {
      * @param account The account ID
      * @param options The options for the list request
      * @return The list templates response
-     * @see <a href="https://developer.dnsimple.com/v2/templates/#list">https://developer.dnsimple.com/v2/templates/#list</a>
+     * @see <a href="https://developer.dnsimple.com/v2/templates/#listTemplates">https://developer.dnsimple.com/v2/templates/#listTemplates</a>
      */
     public PaginatedResponse<Template> listTemplates(Number account, ListOptions options) {
         return client.page(GET, account + "/templates", options, null, Template.class);
-    }
-
-    /**
-     * Get a specific template associated to an account using the templates's ID.
-     *
-     * @param account  The account ID
-     * @param template The template short name or ID
-     * @return The get template response
-     * @see <a href="https://developer.dnsimple.com/v2/templates/#get">https://developer.dnsimple.com/v2/templates/#list</a>
-     */
-    public SimpleResponse<Template> getTemplate(Number account, String template) {
-        return client.simple(GET, account + "/templates/" + template, ListOptions.empty(), null, Template.class);
     }
 
     /**
@@ -65,10 +53,22 @@ public class Templates {
      * @param account The account ID
      * @param options The template options
      * @return The create template response
-     * @see <a href="https://developer.dnsimple.com/v2/templates/#create">https://developer.dnsimple.com/v2/templates/#create</a>
+     * @see <a href="https://developer.dnsimple.com/v2/templates/#createTemplate">https://developer.dnsimple.com/v2/templates/#createTemplate</a>
      */
     public SimpleResponse<Template> createTemplate(Number account, TemplateOptions options) {
         return client.simple(POST, account + "/templates", ListOptions.empty(), options, Template.class);
+    }
+
+    /**
+     * Get a specific template associated to an account using the templates's ID.
+     *
+     * @param account  The account ID
+     * @param template The template short name or ID
+     * @return The get template response
+     * @see <a href="https://developer.dnsimple.com/v2/templates/#getTemplate">https://developer.dnsimple.com/v2/templates/#getTemplate</a>
+     */
+    public SimpleResponse<Template> getTemplate(Number account, String template) {
+        return client.simple(GET, account + "/templates/" + template, ListOptions.empty(), null, Template.class);
     }
 
     /**
@@ -78,7 +78,7 @@ public class Templates {
      * @param template The template short name or ID
      * @param options  The template options
      * @return The update template response
-     * @see <a href="https://developer.dnsimple.com/v2/templates/#update">https://developer.dnsimple.com/v2/templates/#update</a>
+     * @see <a href="https://developer.dnsimple.com/v2/templates/#updateTemplate">https://developer.dnsimple.com/v2/templates/#updateTemplate</a>
      */
     public SimpleResponse<Template> updateTemplate(Number account, String template, TemplateOptions options) {
         return client.simple(PATCH, account + "/templates/" + template, ListOptions.empty(), options, Template.class);
@@ -90,7 +90,7 @@ public class Templates {
      * @param account  The account ID
      * @param template The template short name or ID
      * @return The delete template response
-     * @see <a href="https://developer.dnsimple.com/v2/templates/#delete">https://developer.dnsimple.com/v2/templates/#delete</a>
+     * @see <a href="https://developer.dnsimple.com/v2/templates/#deleteTemplate">https://developer.dnsimple.com/v2/templates/#deleteTemplate</a>
      */
     public EmptyResponse deleteTemplate(Number account, String template) {
         return client.empty(DELETE, account + "/templates/" + template, ListOptions.empty(), null);
@@ -103,7 +103,7 @@ public class Templates {
      * @param template The template short name or ID
      * @param domain   The domain ID or name
      * @return The apply template response
-     * @see <a href="https://developer.dnsimple.com/v2/domains/templates/#apply">https://developer.dnsimple.com/v2/domains/templates/#apply</a>
+     * @see <a href="https://developer.dnsimple.com/v2/domains/templates/#applyTemplateToDomain">https://developer.dnsimple.com/v2/domains/templates/#applyTemplateToDomain</a>
      */
     public EmptyResponse applyTemplate(Number account, String template, String domain) {
         return client.empty(POST, account + "/domains/" + domain + "/templates/" + template, ListOptions.empty(), null);
@@ -115,7 +115,7 @@ public class Templates {
      * @param account  The account ID
      * @param template The template short name or ID
      * @return The list template records response
-     * @see <a href="https://developer.dnsimple.com/v2/templates/records#list">https://developer.dnsimple.com/v2/templates/records#list</a>
+     * @see <a href="https://developer.dnsimple.com/v2/templates/records#listTemplateRecords">https://developer.dnsimple.com/v2/templates/records#listTemplateRecords</a>
      */
     public PaginatedResponse<TemplateRecord> listTemplateRecords(Number account, String template) {
         return client.page(GET, account + "/templates/" + template + "/records", ListOptions.empty(), null, TemplateRecord.class);
@@ -128,23 +128,10 @@ public class Templates {
      * @param template The template short name or ID
      * @param options  The options for the list request
      * @return The list template records response
-     * @see <a href="https://developer.dnsimple.com/v2/templates/records#list">https://developer.dnsimple.com/v2/templates/records#list</a>
+     * @see <a href="https://developer.dnsimple.com/v2/templates/records#listTemplateRecords">https://developer.dnsimple.com/v2/templates/records#listTemplateRecords</a>
      */
     public PaginatedResponse<TemplateRecord> listTemplateRecords(Number account, String template, ListOptions options) {
         return client.page(GET, account + "/templates/" + template + "/records", options, null, TemplateRecord.class);
-    }
-
-    /**
-     * Get a specific record associated to a template using the record's ID.
-     *
-     * @param account  The account ID
-     * @param template The template short name or ID
-     * @param record   The record ID
-     * @return The get template record response
-     * @see <a href="https://developer.dnsimple.com/v2/templates/records/#get">https://developer.dnsimple.com/v2/templates/records/#get</a>
-     */
-    public SimpleResponse<TemplateRecord> getTemplateRecord(Number account, String template, Number record) {
-        return client.simple(GET, account + "/templates/" + template + "/records/" + record, ListOptions.empty(), null, TemplateRecord.class);
     }
 
     /**
@@ -154,10 +141,23 @@ public class Templates {
      * @param template The template short name or ID
      * @param options  The template record options
      * @return The create template record response
-     * @see <a href="https://developer.dnsimple.com/v2/templates/records#create">https://developer.dnsimple.com/v2/templates/records#create</a>
+     * @see <a href="https://developer.dnsimple.com/v2/templates/records#createTemplateRecord">https://developer.dnsimple.com/v2/templates/records#createTemplateRecord</a>
      */
     public SimpleResponse<TemplateRecord> createTemplateRecord(Number account, String template, TemplateRecordOptions options) {
         return client.simple(POST, account + "/templates/" + template + "/records", ListOptions.empty(), options, TemplateRecord.class);
+    }
+
+    /**
+     * Get a specific record associated to a template using the record's ID.
+     *
+     * @param account  The account ID
+     * @param template The template short name or ID
+     * @param record   The record ID
+     * @return The get template record response
+     * @see <a href="https://developer.dnsimple.com/v2/templates/records/#getTemplateRecord">https://developer.dnsimple.com/v2/templates/records/#getTemplateRecord</a>
+     */
+    public SimpleResponse<TemplateRecord> getTemplateRecord(Number account, String template, Number record) {
+        return client.simple(GET, account + "/templates/" + template + "/records/" + record, ListOptions.empty(), null, TemplateRecord.class);
     }
 
     /**
@@ -167,7 +167,7 @@ public class Templates {
      * @param template The template short name or ID
      * @param record   The record ID
      * @return The delete template record response
-     * @see <a href="https://developer.dnsimple.com/v2/templates/records#delete">https://developer.dnsimple.com/v2/templates/records#delete</a>
+     * @see <a href="https://developer.dnsimple.com/v2/templates/records#deleteTemplateRecord">https://developer.dnsimple.com/v2/templates/records#deleteTemplateRecord</a>
      */
     public EmptyResponse deleteTemplateRecord(Number account, String template, Number record) {
         return client.empty(DELETE, account + "/templates/" + template + "/records/" + record, ListOptions.empty(), null);

--- a/src/main/java/com/dnsimple/endpoints/VanityNameServers.java
+++ b/src/main/java/com/dnsimple/endpoints/VanityNameServers.java
@@ -27,7 +27,7 @@ public class VanityNameServers {
      * @param account The account ID
      * @param domain  The domain name or ID
      * @return The enable vanity name server response
-     * @see <a href="https://developer.dnsimple.com/v2/domains/vanity/#enable">https://developer.dnsimple.com/v2/domains/vanity/#enable</a>
+     * @see <a href="https://developer.dnsimple.com/v2/domains/vanity/#enableVanityNameServers">https://developer.dnsimple.com/v2/domains/vanity/#enableVanityNameServers</a>
      */
     public ListResponse<VanityNameServer> enableVanityNameServers(Number account, String domain) {
         return client.list(PUT, account + "/vanity/" + domain, ListOptions.empty(), null, VanityNameServer.class);
@@ -39,7 +39,7 @@ public class VanityNameServers {
      * @param account The account ID
      * @param domain  The domain name or ID
      * @return The disable vanity name server response
-     * @see <a href="https://developer.dnsimple.com/v2/domains/vanity/#disable">https://developer.dnsimple.com/v2/domains/vanity/#disable</a>
+     * @see <a href="https://developer.dnsimple.com/v2/domains/vanity/#disableVanityNameServers">https://developer.dnsimple.com/v2/domains/vanity/#disableVanityNameServers</a>
      */
     public EmptyResponse disableVanityNameServers(Number account, String domain) {
         return client.empty(DELETE, account + "/vanity/" + domain, ListOptions.empty(), null);

--- a/src/main/java/com/dnsimple/endpoints/Webhooks.java
+++ b/src/main/java/com/dnsimple/endpoints/Webhooks.java
@@ -27,7 +27,7 @@ public class Webhooks {
      *
      * @param account The account ID
      * @return The list webhooks response
-     * @see <a href="https://developer.dnsimple.com/v2/webhooks/#list">https://developer.dnsimple.com/v2/webhooks/#list</a>
+     * @see <a href="https://developer.dnsimple.com/v2/webhooks/#listWebhooks">https://developer.dnsimple.com/v2/webhooks/#listWebhooks</a>
      */
     public ListResponse<Webhook> listWebhooks(Number account) {
         return client.list(GET, account + "/webhooks", ListOptions.empty(), null, Webhook.class);
@@ -39,22 +39,10 @@ public class Webhooks {
      * @param account The account ID
      * @param options The options for the list request
      * @return The list webhooks response
-     * @see <a href="https://developer.dnsimple.com/v2/webhooks/#list">https://developer.dnsimple.com/v2/webhooks/#list</a>
+     * @see <a href="https://developer.dnsimple.com/v2/webhooks/#listWebhooks">https://developer.dnsimple.com/v2/webhooks/#listWebhooks</a>
      */
     public ListResponse<Webhook> listWebhooks(Number account, ListOptions options) {
         return client.list(GET, account + "/webhooks", options, null, Webhook.class);
-    }
-
-    /**
-     * Get a specific webhook associated to an account using the webhook's ID.
-     *
-     * @param account   The account ID
-     * @param webhookId The webhook ID
-     * @return The get webhook response
-     * @see <a href="https://developer.dnsimple.com/v2/webhooks/#get">https://developer.dnsimple.com/v2/webhooks/#get</a>
-     */
-    public SimpleResponse<Webhook> getWebhook(Number account, Number webhookId) {
-        return client.simple(GET, account + "/webhooks/" + webhookId, ListOptions.empty(), null, Webhook.class);
     }
 
     /**
@@ -63,10 +51,22 @@ public class Webhooks {
      * @param account The account ID
      * @param url     The url of the webhook
      * @return The create webhook response
-     * @see <a href="https://developer.dnsimple.com/v2/webhooks/#create">https://developer.dnsimple.com/v2/webhooks/#create</a>
+     * @see <a href="https://developer.dnsimple.com/v2/webhooks/#createWebhook">https://developer.dnsimple.com/v2/webhooks/#createWebhook</a>
      */
     public SimpleResponse<Webhook> createWebhook(Number account, String url) {
         return client.simple(POST, account + "/webhooks", ListOptions.empty(), singletonMap("url", url), Webhook.class);
+    }
+
+    /**
+     * Get a specific webhook associated to an account using the webhook's ID.
+     *
+     * @param account   The account ID
+     * @param webhookId The webhook ID
+     * @return The get webhook response
+     * @see <a href="https://developer.dnsimple.com/v2/webhooks/#getWebhook">https://developer.dnsimple.com/v2/webhooks/#getWebhook</a>
+     */
+    public SimpleResponse<Webhook> getWebhook(Number account, Number webhookId) {
+        return client.simple(GET, account + "/webhooks/" + webhookId, ListOptions.empty(), null, Webhook.class);
     }
 
     /**
@@ -75,7 +75,7 @@ public class Webhooks {
      * @param account   The account ID
      * @param webhookId The webhook ID
      * @return The delete webhook response
-     * @see <a href="https://developer.dnsimple.com/v2/webhooks/#delete">https://developer.dnsimple.com/v2/webhooks/#delete</a>
+     * @see <a href="https://developer.dnsimple.com/v2/webhooks/#deleteWebhook">https://developer.dnsimple.com/v2/webhooks/#deleteWebhook</a>
      */
     public EmptyResponse deleteWebhook(Number account, Number webhookId) {
         return client.empty(DELETE, account + "/webhooks/" + webhookId, ListOptions.empty(), null);

--- a/src/main/java/com/dnsimple/endpoints/Zones.java
+++ b/src/main/java/com/dnsimple/endpoints/Zones.java
@@ -33,7 +33,7 @@ public class Zones {
      *
      * @param account The account ID
      * @return The list zones response
-     * @see <a href="https://developer.dnsimple.com/v2/zones/#list">https://developer.dnsimple.com/v2/zones/#list</a>
+     * @see <a href="https://developer.dnsimple.com/v2/zones/#listZones">https://developer.dnsimple.com/v2/zones/#listZones</a>
      */
     public PaginatedResponse<Zone> listZones(Number account) {
         return client.page(GET, account + "/zones", ListOptions.empty(), null, Zone.class);
@@ -45,7 +45,7 @@ public class Zones {
      * @param account The account ID
      * @param options The options for the list request
      * @return The list zones response
-     * @see <a href="https://developer.dnsimple.com/v2/zones/#list">https://developer.dnsimple.com/v2/zones/#list</a>
+     * @see <a href="https://developer.dnsimple.com/v2/zones/#listZones">https://developer.dnsimple.com/v2/zones/#listZones</a>
      */
     public PaginatedResponse<Zone> listZones(Number account, ListOptions options) {
         return client.page(GET, account + "/zones", options, null, Zone.class);
@@ -57,7 +57,7 @@ public class Zones {
      * @param account The account ID
      * @param zone    The zone name
      * @return The get zone response
-     * @see <a href="https://developer.dnsimple.com/v2/zones/#get">https://developer.dnsimple.com/v2/zones/#get</a>
+     * @see <a href="https://developer.dnsimple.com/v2/zones/#getZone">https://developer.dnsimple.com/v2/zones/#getZone</a>
      */
     public SimpleResponse<Zone> getZone(Number account, String zone) {
         return client.simple(GET, account + "/zones/" + zone, ListOptions.empty(), null, Zone.class);
@@ -69,7 +69,7 @@ public class Zones {
      * @param account The account ID
      * @param zone    The zone name
      * @return The get zone file response
-     * @see <a href="https://developer.dnsimple.com/v2/zones/#get-file">https://developer.dnsimple.com/v2/zones/#get-file</a>
+     * @see <a href="https://developer.dnsimple.com/v2/zones/#getZoneFile">https://developer.dnsimple.com/v2/zones/#getZoneFile</a>
      */
     public SimpleResponse<ZoneFile> getZoneFile(Number account, String zone) {
         return client.simple(GET, account + "/zones/" + zone + "/file", ListOptions.empty(), null, ZoneFile.class);
@@ -88,25 +88,12 @@ public class Zones {
     }
 
     /**
-     * Checks if a zone record change is fully distributed to all our nameservers of our regions.
-     *
-     * @param account The account ID
-     * @param zone    The zone name
-     * @param record  The zone record ID
-     * @return The result of the check
-     * @see <a href="https://developer.dnsimple.com/v2/zones/#checkZoneRecordDistribution">https://developer.dnsimple.com/v2/zones/#checkZoneRecordDistribution</a>
-     */
-    public SimpleResponse<ZoneDistribution> checkZoneRecordDistribution(Number account, String zone, Number record) {
-        return client.simple(GET, account + "/zones/" + zone + "/records/" + record + "/distribution", ListOptions.empty(), null, ZoneDistribution.class);
-    }
-
-    /**
      * Lists the records in the zone.
      *
      * @param account The account ID
      * @param zone    The zone name
      * @return The list zone records response
-     * @see <a href="https://developer.dnsimple.com/v2/zones/records/#list">https://developer.dnsimple.com/v2/zones/records/#list</a>
+     * @see <a href="https://developer.dnsimple.com/v2/zones/records/#listZoneRecords">https://developer.dnsimple.com/v2/zones/records/#listZoneRecords</a>
      */
     public PaginatedResponse<ZoneRecord> listZoneRecords(Number account, String zone) {
         return client.page(GET, account + "/zones/" + zone + "/records", ListOptions.empty(), null, ZoneRecord.class);
@@ -119,23 +106,10 @@ public class Zones {
      * @param zone    The zone name
      * @param options The options for the list request
      * @return The list zone records response
-     * @see <a href="https://developer.dnsimple.com/v2/zones/records/#list">https://developer.dnsimple.com/v2/zones/records/#list</a>
+     * @see <a href="https://developer.dnsimple.com/v2/zones/records/#listZoneRecords">https://developer.dnsimple.com/v2/zones/records/#listZoneRecords</a>
      */
     public PaginatedResponse<ZoneRecord> listZoneRecords(Number account, String zone, ListOptions options) {
         return client.page(GET, account + "/zones/" + zone + "/records", options, null, ZoneRecord.class);
-    }
-
-    /**
-     * Get a specific record associated to a zone using the zone's name or ID.
-     *
-     * @param account The account ID
-     * @param zone    The zone name
-     * @param record  The zone record ID
-     * @return The get zone record response
-     * @see <a href="https://developer.dnsimple.com/v2/zones/records/#get">https://developer.dnsimple.com/v2/zones/records/#get</a>
-     */
-    public SimpleResponse<ZoneRecord> getZoneRecord(Number account, String zone, Number record) {
-        return client.simple(GET, account + "/zones/" + zone + "/records/" + record, ListOptions.empty(), null, ZoneRecord.class);
     }
 
     /**
@@ -145,10 +119,23 @@ public class Zones {
      * @param zone    The zone name
      * @param options Options for the Zone record
      * @return The create zone record response
-     * @see <a href="https://developer.dnsimple.com/v2/zones/records/#create">https://developer.dnsimple.com/v2/zones/records/#create</a>
+     * @see <a href="https://developer.dnsimple.com/v2/zones/records/#createZoneRecord">https://developer.dnsimple.com/v2/zones/records/#createZoneRecord</a>
      */
     public SimpleResponse<ZoneRecord> createZoneRecord(Number account, String zone, ZoneRecordOptions options) {
         return client.simple(POST, account + "/zones/" + zone + "/records", ListOptions.empty(), options, ZoneRecord.class);
+    }
+
+    /**
+     * Get a specific record associated to a zone using the zone's name or ID.
+     *
+     * @param account The account ID
+     * @param zone    The zone name
+     * @param record  The zone record ID
+     * @return The get zone record response
+     * @see <a href="https://developer.dnsimple.com/v2/zones/records/#getZoneRecord">https://developer.dnsimple.com/v2/zones/records/#getZoneRecord</a>
+     */
+    public SimpleResponse<ZoneRecord> getZoneRecord(Number account, String zone, Number record) {
+        return client.simple(GET, account + "/zones/" + zone + "/records/" + record, ListOptions.empty(), null, ZoneRecord.class);
     }
 
     /**
@@ -159,7 +146,7 @@ public class Zones {
      * @param record     The zone record ID
      * @param options The options to update the Zone record
      * @return The update zone record response
-     * @see <a href="https://developer.dnsimple.com/v2/zones/records/#update">https://developer.dnsimple.com/v2/zones/records/#update</a>
+     * @see <a href="https://developer.dnsimple.com/v2/zones/records/#updateZoneRecord">https://developer.dnsimple.com/v2/zones/records/#updateZoneRecord</a>
      */
     public SimpleResponse<ZoneRecord> updateZoneRecord(Number account, String zone, Number record, ZoneRecordUpdateOptions options) {
         return client.simple(PATCH, account + "/zones/" + zone + "/records/" + record, ListOptions.empty(), options, ZoneRecord.class);
@@ -172,9 +159,22 @@ public class Zones {
      * @param zone    The zone name
      * @param record  The zone record ID
      * @return The delete zone record response
-     * @see <a href="https://developer.dnsimple.com/v2/zones/records/#delete">https://developer.dnsimple.com/v2/zones/records/#delete</a>
+     * @see <a href="https://developer.dnsimple.com/v2/zones/records/#deleteZoneRecord">https://developer.dnsimple.com/v2/zones/records/#deleteZoneRecord</a>
      */
     public EmptyResponse deleteZoneRecord(Number account, String zone, Number record) {
         return client.empty(DELETE, account + "/zones/" + zone + "/records/" + record, ListOptions.empty(), null);
+    }
+
+    /**
+     * Checks if a zone record change is fully distributed to all our nameservers of our regions.
+     *
+     * @param account The account ID
+     * @param zone    The zone name
+     * @param record  The zone record ID
+     * @return The result of the check
+     * @see <a href="https://developer.dnsimple.com/v2/zones/#checkZoneRecordDistribution">https://developer.dnsimple.com/v2/zones/#checkZoneRecordDistribution</a>
+     */
+    public SimpleResponse<ZoneDistribution> checkZoneRecordDistribution(Number account, String zone, Number record) {
+        return client.simple(GET, account + "/zones/" + zone + "/records/" + record + "/distribution", ListOptions.empty(), null, ZoneDistribution.class);
     }
 }

--- a/src/main/java/com/dnsimple/exception/BadRequestException.java
+++ b/src/main/java/com/dnsimple/exception/BadRequestException.java
@@ -1,14 +1,22 @@
 package com.dnsimple.exception;
 
+import java.util.Map;
+
 public class BadRequestException extends DnsimpleException {
     private final int statusCode;
+    private final Map<String, Object> body;
 
-    public BadRequestException(int statusCode) {
+    public BadRequestException(int statusCode, Map<String, Object> body) {
         super("The server responded with an HTTP " + statusCode + " error. Please, review the request options and attributes");
         this.statusCode = statusCode;
+        this.body = body;
     }
 
     public int getStatusCode() {
         return statusCode;
+    }
+
+    public Map<String, Object> getBody() {
+        return body;
     }
 }

--- a/src/main/java/com/dnsimple/request/DomainCheckPremiumPriceAction.java
+++ b/src/main/java/com/dnsimple/request/DomainCheckPremiumPriceAction.java
@@ -1,0 +1,5 @@
+package com.dnsimple.request;
+
+public enum DomainCheckPremiumPriceAction {
+    REGISTRATION, RENEWAL, TRANSFER
+}

--- a/src/test/java/com/dnsimple/endpoints/DomainsTest.java
+++ b/src/test/java/com/dnsimple/endpoints/DomainsTest.java
@@ -109,11 +109,4 @@ public class DomainsTest extends DnsimpleTestBase {
         assertThat(server.getRecordedRequest().getMethod(), is(DELETE));
         assertThat(server.getRecordedRequest().getPath(), is("/v2/1/domains/example.com"));
     }
-
-    @Test
-    public void testResetDomainToken() {
-        server.stubFixtureAt("resetDomainToken/success.http");
-        SimpleResponse<Domain> response = client.domains.resetDomainToken(1, "example.com");
-        assertThat(response.getData().getId(), is(1L));
-    }
 }

--- a/src/test/java/com/dnsimple/endpoints/RegistrarTest.java
+++ b/src/test/java/com/dnsimple/endpoints/RegistrarTest.java
@@ -36,7 +36,7 @@ public class RegistrarTest extends DnsimpleTestBase {
     @Test
     public void testCheckDomainPremiumPrice() {
         server.stubFixtureAt("checkDomainPremiumPrice/success.http");
-        DomainPremiumPriceCheck premiumPrice = client.registrar.checkDomainPremiumPrice(1010, "cocoo.co", REGISTRATION).getData();
+        DomainPremiumPriceCheck premiumPrice = client.registrar.getDomainPremiumPrice(1010, "cocoo.co", REGISTRATION).getData();
         assertThat(server.getRecordedRequest().getMethod(), is(GET));
         assertThat(server.getRecordedRequest().getPath(), is("/v2/1010/registrar/domains/cocoo.co/premium_price?action=registration"));
         assertThat(premiumPrice.getPremiumPrice(), is("2640.00"));
@@ -47,7 +47,7 @@ public class RegistrarTest extends DnsimpleTestBase {
     public void testCheckDomainPremiumPrice_400_notAPremiumDomain() {
         server.stubFixtureAt("checkDomainPremiumPrice/error_400_not_a_premium_domain.http");
         assertThat(
-                () -> client.registrar.checkDomainPremiumPrice(1010, "cocotero.love", REGISTRATION),
+                () -> client.registrar.getDomainPremiumPrice(1010, "cocotero.love", REGISTRATION),
                 thrownException(allOf(
                         is(instanceOf(BadRequestException.class)),
                         property(
@@ -62,7 +62,7 @@ public class RegistrarTest extends DnsimpleTestBase {
     public void testCheckDomainPremiumPrice_400_tld_not_supported() {
         server.stubFixtureAt("checkDomainPremiumPrice/error_400_tld_not_supported.http");
         assertThat(
-                () -> client.registrar.checkDomainPremiumPrice(1010, "cocotero.love", REGISTRATION),
+                () -> client.registrar.getDomainPremiumPrice(1010, "cocotero.love", REGISTRATION),
                 thrownException(allOf(
                         is(instanceOf(BadRequestException.class)),
                         property(
@@ -186,7 +186,7 @@ public class RegistrarTest extends DnsimpleTestBase {
     @Test
     public void testTransferDomainOut() {
         server.stubFixtureAt("authorizeDomainTransferOut/success.http");
-        client.registrar.transferDomainOut(1010, "example.com");
+        client.registrar.authorizeTransferOut(1010, "example.com");
         assertThat(server.getRecordedRequest().getMethod(), is(POST));
         assertThat(server.getRecordedRequest().getPath(), is("/v2/1010/registrar/domains/example.com/authorize_transfer_out"));
     }

--- a/src/test/java/com/dnsimple/endpoints/TemplatesTest.java
+++ b/src/test/java/com/dnsimple/endpoints/TemplatesTest.java
@@ -10,9 +10,7 @@ import com.dnsimple.tools.DnsimpleTestBase;
 import org.junit.Test;
 
 import java.time.OffsetDateTime;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import static com.dnsimple.http.HttpMethod.*;
 import static com.dnsimple.tools.CustomMatchers.number;

--- a/src/test/resources/com/dnsimple/checkDomainPremiumPrice/error_400_not_a_premium_domain.http
+++ b/src/test/resources/com/dnsimple/checkDomainPremiumPrice/error_400_not_a_premium_domain.http
@@ -1,0 +1,19 @@
+HTTP/1.1 400 Bad Request
+Server: nginx
+Date: Mon, 27 Jul 2020 13:43:02 GMT
+Content-Type: application/json; charset=utf-8
+Transfer-Encoding: identity
+Connection: keep-alive
+X-RateLimit-Limit: 4800
+X-RateLimit-Remaining: 4786
+X-RateLimit-Reset: 1595859922
+Cache-Control: no-cache
+X-Request-Id: 382b409c-0f90-4758-af3b-0bccd31a9d0d
+X-Runtime: 1.346405
+X-Frame-Options: DENY
+X-Content-Type-Options: nosniff
+X-XSS-Protection: 1; mode=block
+X-Download-Options: noopen
+X-Permitted-Cross-Domain-Policies: none
+
+{"message":"`cocotero.love` is not a premium domain for registration"}

--- a/src/test/resources/com/dnsimple/checkDomainPremiumPrice/error_400_tld_not_supported.http
+++ b/src/test/resources/com/dnsimple/checkDomainPremiumPrice/error_400_tld_not_supported.http
@@ -1,0 +1,19 @@
+HTTP/1.1 400 Bad Request
+Server: nginx
+Date: Mon, 27 Jul 2020 13:41:23 GMT
+Content-Type: application/json; charset=utf-8
+Transfer-Encoding: identity
+Connection: keep-alive
+X-RateLimit-Limit: 2400
+X-RateLimit-Remaining: 2398
+X-RateLimit-Reset: 1595860823
+Cache-Control: no-cache
+X-Request-Id: 6986cca3-4f57-4814-9e81-1c484d61c7ea
+X-Runtime: 0.007339
+X-Frame-Options: DENY
+X-Content-Type-Options: nosniff
+X-XSS-Protection: 1; mode=block
+X-Download-Options: noopen
+X-Permitted-Cross-Domain-Policies: none
+
+{"message":"TLD .LOVE is not supported"}

--- a/src/test/resources/com/dnsimple/checkDomainPremiumPrice/success.http
+++ b/src/test/resources/com/dnsimple/checkDomainPremiumPrice/success.http
@@ -1,0 +1,21 @@
+HTTP/1.1 200 OK
+Server: nginx
+Date: Mon, 27 Jul 2020 13:58:50 GMT
+Content-Type: application/json; charset=utf-8
+Transfer-Encoding: identity
+Connection: keep-alive
+X-RateLimit-Limit: 4800
+X-RateLimit-Remaining: 4769
+X-RateLimit-Reset: 1595859923
+ETag: W/"54b4776b898065f2f551fc33465d0936"
+Cache-Control: max-age=0, private, must-revalidate
+X-Request-Id: 75c5090e-8000-4e95-a516-ffd09383f641
+X-Runtime: 2.380524
+X-Frame-Options: DENY
+X-Content-Type-Options: nosniff
+X-XSS-Protection: 1; mode=block
+X-Download-Options: noopen
+X-Permitted-Cross-Domain-Policies: none
+Strict-Transport-Security: max-age=31536000
+
+{"data":{"premium_price":"2640.00","action":"registration"}}


### PR DESCRIPTION
Fixes #74 

This PR aligns the endpoint actions with the current API docs:
- Removed decommissioned `Domains.resetDomainToken` action
- Added missing `Registrar.getDomainPremiumPrice` action
- Fixes links to API docs in doc blocks
- Fixes some names and the order in which actions show up in the endpoint classes

This PR also improves the `BadRequestException` class to include the server's response body that might come with context and information about why a request has been rejected by the API server.