### PR TITLE
Implement registrar methods for Domain Prices API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### `main`
 
+- NEW: Added `client.registrar.getDomainPrices` to retrieve if domain is premium and prices to register, transfer, and renewal. (dnsimple/dnsimple-java#93)
+
 ### Release 0.8.1
 
 - Fix: Align arguments of `Domain.listPushes()` with current API (#81)

--- a/examples/src/main/java/Domains.java
+++ b/examples/src/main/java/Domains.java
@@ -39,6 +39,18 @@ public class Domains {
                 contact.getId()
         );
 
+        // Get the prices to register the domain
+        var prices = client.registrar.getDomainPrices(
+                accountId,
+                domainName
+        ).getData();
+        System.out.printf(
+                "Domain %s - premium? %b - registration price: %f",
+                domainName,
+                prices.isPremium(),
+                prices.getRegistrationPrice()
+        )
+
         // Register the domain
         var registration = client.registrar.registerDomain(
                 accountId,

--- a/src/main/java/com/dnsimple/data/DomainPrice.java
+++ b/src/main/java/com/dnsimple/data/DomainPrice.java
@@ -1,0 +1,37 @@
+package com.dnsimple.data;
+
+public class DomainPrice {
+    private final String domain;
+    private final Boolean premium;
+    private final Float registrationPrice;
+    private final Float renewalPrice;
+    private final Float transferPrice;
+
+    public DomainPrice(String domain, Boolean premium, Float registrationPrice, Float renewalPrice, Float transferPrice) {
+        this.domain = domain;
+        this.premium = premium;
+        this.registrationPrice = registrationPrice;
+        this.renewalPrice = renewalPrice;
+        this.transferPrice = transferPrice;
+    }
+
+    public String getDomain() {
+        return domain;
+    }
+
+    public Boolean isPremium() {
+        return premium;
+    }
+
+    public Float getRegistrationPrice() {
+        return registrationPrice;
+    }
+
+    public Float getRenewalPrice() {
+        return renewalPrice;
+    }
+
+    public Float getTransferPrice() {
+        return transferPrice;
+    }
+}

--- a/src/main/java/com/dnsimple/endpoints/Registrar.java
+++ b/src/main/java/com/dnsimple/endpoints/Registrar.java
@@ -50,6 +50,19 @@ public class Registrar {
     }
 
     /**
+     * Get prices for registration, transfer, and renewal for a domain.
+     *
+     * @param account    The account ID
+     * @param domainName The domain to check the prices
+     *
+     * @return the domain prices response
+     * @see <a href="https://developer.dnsimple.com/v2/registrar/#getDomainPrices">https://developer.dnsimple.com/v2/registrar/#getDomainPrices</a>
+     */
+    public SimpleResponse<DomainPrice> getDomainPrices(Number account, String domainName) {
+        return client.simple(GET, account + "/registrar/domains/" + domainName + "/prices", ListOptions.empty(), null, DomainPrice.class);
+    }
+
+    /**
      * Registers a domain.
      *
      * @param account    The account ID

--- a/src/test/java/com/dnsimple/endpoints/RegistrarTest.java
+++ b/src/test/java/com/dnsimple/endpoints/RegistrarTest.java
@@ -74,6 +74,28 @@ public class RegistrarTest extends DnsimpleTestBase {
     }
 
     @Test
+    public void testGetDomainPrices() {
+        server.stubFixtureAt("getDomainPrices/success.http");
+
+        DomainPrice prices = client.registrar.getDomainPrices(1010, "bingo.pizza").getData();
+
+        assertThat(server.getRecordedRequest().getMethod(), is(GET));
+        assertThat(server.getRecordedRequest().getPath(), is("/v2/1010/registrar/domains/bingo.pizza/prices"));
+        assertThat(prices.getDomain(), is("bingo.pizza"));
+        assertThat(prices.isPremium(), is(true));
+        assertThat(prices.getRegistrationPrice(), is(20.0F));
+        assertThat(prices.getRenewalPrice(), is(20.0F));
+        assertThat(prices.getTransferPrice(), is(20.0F));
+    }
+
+    @Test(expected = DnsimpleException.class)
+    public void testGetDomainPricesWithANotSupportedTLD() {
+        server.stubFixtureAt("getDomainPrices/failure.http");
+
+        client.registrar.getDomainPrices(1010, "bing.pineapple");
+    }
+
+    @Test
     public void testRegisterDomain() {
         server.stubFixtureAt("registerDomain/success.http");
         RegistrationOptions options = RegistrationOptions.of(10);

--- a/src/test/resources/com/dnsimple/getDomainPrices/failure.http
+++ b/src/test/resources/com/dnsimple/getDomainPrices/failure.http
@@ -1,0 +1,20 @@
+HTTP/1.1 400 Bad Request
+Server: nginx
+Date: Mon, 08 Mar 2021 14:35:58 GMT
+Content-Type: application/json; charset=utf-8
+Transfer-Encoding: identity
+Connection: keep-alive
+X-RateLimit-Limit: 2400
+X-RateLimit-Remaining: 2396
+X-RateLimit-Reset: 1615217645
+Cache-Control: no-cache
+X-Request-Id: e414a674-63bb-4e54-b714-db5b516bb190
+X-Runtime: 0.009579
+X-Frame-Options: DENY
+X-Content-Type-Options: nosniff
+X-XSS-Protection: 1; mode=block
+X-Download-Options: noopen
+X-Permitted-Cross-Domain-Policies: none
+Content-Security-Policy: frame-ancestors 'none'
+
+{"message":"TLD .PINEAPPLE is not supported"}

--- a/src/test/resources/com/dnsimple/getDomainPrices/success.http
+++ b/src/test/resources/com/dnsimple/getDomainPrices/success.http
@@ -1,0 +1,22 @@
+HTTP/1.1 200 OK
+Server: nginx
+Date: Mon, 08 Mar 2021 14:35:26 GMT
+Content-Type: application/json; charset=utf-8
+Transfer-Encoding: identity
+Connection: keep-alive
+X-RateLimit-Limit: 2400
+X-RateLimit-Remaining: 2397
+X-RateLimit-Reset: 1615217645
+ETag: W/"2104f27f2877f429295359cfc409f9f7"
+Cache-Control: max-age=0, private, must-revalidate
+X-Request-Id: b0d9e000-58a6-4254-af43-8735d26e12d9
+X-Runtime: 9.129301
+X-Frame-Options: DENY
+X-Content-Type-Options: nosniff
+X-XSS-Protection: 1; mode=block
+X-Download-Options: noopen
+X-Permitted-Cross-Domain-Policies: none
+Content-Security-Policy: frame-ancestors 'none'
+Strict-Transport-Security: max-age=31536000
+
+{"data":{"domain":"bingo.pizza","premium":true,"registration_price":20.0,"renewal_price":20.0,"transfer_price":20.0}}


### PR DESCRIPTION
This commit introduces a new client method for our Domain Prices API:
- registrar.getDomainPrices - Retrieves the prices for a domain.

It also includes if the domain is premium or not in the response.