### PR TITLE
Don't send `regions` for global dns records

### DIFF
--- a/src/main/java/com/dnsimple/endpoints/Zones.java
+++ b/src/main/java/com/dnsimple/endpoints/Zones.java
@@ -12,8 +12,6 @@ import com.dnsimple.response.EmptyResponse;
 import com.dnsimple.response.PaginatedResponse;
 import com.dnsimple.response.SimpleResponse;
 
-import java.util.Map;
-
 import static com.dnsimple.http.HttpMethod.*;
 
 /**

--- a/src/main/java/com/dnsimple/endpoints/Zones.java
+++ b/src/main/java/com/dnsimple/endpoints/Zones.java
@@ -122,7 +122,7 @@ public class Zones {
      * @see <a href="https://developer.dnsimple.com/v2/zones/records/#createZoneRecord">https://developer.dnsimple.com/v2/zones/records/#createZoneRecord</a>
      */
     public SimpleResponse<ZoneRecord> createZoneRecord(Number account, String zone, ZoneRecordOptions options) {
-        return client.simple(POST, account + "/zones/" + zone + "/records", ListOptions.empty(), options, ZoneRecord.class);
+        return client.simple(POST, account + "/zones/" + zone + "/records", ListOptions.empty(), options.asPayload(), ZoneRecord.class);
     }
 
     /**

--- a/src/main/java/com/dnsimple/endpoints/Zones.java
+++ b/src/main/java/com/dnsimple/endpoints/Zones.java
@@ -147,7 +147,7 @@ public class Zones {
      * @see <a href="https://developer.dnsimple.com/v2/zones/records/#updateZoneRecord">https://developer.dnsimple.com/v2/zones/records/#updateZoneRecord</a>
      */
     public SimpleResponse<ZoneRecord> updateZoneRecord(Number account, String zone, Number record, ZoneRecordUpdateOptions options) {
-        return client.simple(PATCH, account + "/zones/" + zone + "/records/" + record, ListOptions.empty(), options, ZoneRecord.class);
+        return client.simple(PATCH, account + "/zones/" + zone + "/records/" + record, ListOptions.empty(), options.asPayload(), ZoneRecord.class);
     }
 
     /**

--- a/src/main/java/com/dnsimple/request/ZoneRecordOptions.java
+++ b/src/main/java/com/dnsimple/request/ZoneRecordOptions.java
@@ -57,9 +57,7 @@ public class ZoneRecordOptions {
     }
 
     /**
-     * Returns a map with this object's attributes and prunes the `regions` attribute if it's empty
-     *
-     * @return <Map<String,Object>>
+     * @return a map with this object's attributes and prunes the `regions` attribute if it's empty
      */
     public Map<String, Object> asPayload() {
         var map = new HashMap<String, Object>();

--- a/src/main/java/com/dnsimple/request/ZoneRecordOptions.java
+++ b/src/main/java/com/dnsimple/request/ZoneRecordOptions.java
@@ -1,7 +1,9 @@
 package com.dnsimple.request;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
@@ -29,7 +31,7 @@ public class ZoneRecordOptions {
      * @param content the content of the record
      */
     public static ZoneRecordOptions of(String name, String type, String content) {
-        return new ZoneRecordOptions(name, type, content, null, null, singletonList("global"));
+        return new ZoneRecordOptions(name, type, content, null, null, emptyList());
     }
 
     /**
@@ -53,4 +55,22 @@ public class ZoneRecordOptions {
     public ZoneRecordOptions regions(String... regions) {
         return new ZoneRecordOptions(name, type, content, ttl, priority, Arrays.asList(regions));
     }
+
+    /**
+     * Returns a map with this object's attributes and prunes the `regions` attribute if it's empty
+     *
+     * @return <Map<String,Object>>
+     */
+    public Map<String, Object> asPayload() {
+        var map = new HashMap<String, Object>();
+        map.put("name", name);
+        map.put("type", type);
+        map.put("content", content);
+        map.put("ttl", ttl);
+        map.put("priority", priority);
+        if (!regions.isEmpty())
+            map.put("regions", regions);
+        return map;
+    }
+
 }

--- a/src/main/java/com/dnsimple/request/ZoneRecordUpdateOptions.java
+++ b/src/main/java/com/dnsimple/request/ZoneRecordUpdateOptions.java
@@ -1,10 +1,11 @@
 package com.dnsimple.request;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static java.util.Collections.emptyList;
-import static java.util.Collections.singletonList;
 
 public class ZoneRecordUpdateOptions {
     private final String name;
@@ -22,7 +23,7 @@ public class ZoneRecordUpdateOptions {
     }
 
     public static ZoneRecordUpdateOptions empty() {
-        return new ZoneRecordUpdateOptions(null, null, null, null, singletonList("global"));
+        return new ZoneRecordUpdateOptions(null, null, null, null, emptyList());
     }
 
     /**
@@ -59,5 +60,21 @@ public class ZoneRecordUpdateOptions {
      */
     public ZoneRecordUpdateOptions regions(String... regions) {
         return new ZoneRecordUpdateOptions(name, content, ttl, priority, Arrays.asList(regions));
+    }
+
+    /**
+     * Returns a map with this object's attributes and prunes the `regions` attribute if it's empty
+     *
+     * @return <Map<String,Object>>
+     */
+    public Map<String, Object> asPayload() {
+        var map = new HashMap<String, Object>();
+        map.put("name", name);
+        map.put("content", content);
+        map.put("ttl", ttl);
+        map.put("priority", priority);
+        if (!regions.isEmpty())
+            map.put("regions", regions);
+        return map;
     }
 }

--- a/src/main/java/com/dnsimple/request/ZoneRecordUpdateOptions.java
+++ b/src/main/java/com/dnsimple/request/ZoneRecordUpdateOptions.java
@@ -63,9 +63,7 @@ public class ZoneRecordUpdateOptions {
     }
 
     /**
-     * Returns a map with this object's attributes and prunes the `regions` attribute if it's empty
-     *
-     * @return <Map<String,Object>>
+     * @return a map with this object's attributes and prunes the `regions` attribute if it's empty
      */
     public Map<String, Object> asPayload() {
         var map = new HashMap<String, Object>();


### PR DESCRIPTION
Fixes #103 

This PR ensures we will not send a `regions` attribute when creating or updating a DNS record that doesn't specify any region.