### PR TITLE
Add getter for the attribute errors in `BadRequestException`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## `main`
 
 - CHANGED: Deprecate Certificate's `contact_id` (dnsimple/dnsimple-java#123)
+- CHANGED: Add getter for attribute errors in `BadRequestException` (dnsimple/dnsimple-java#135)
 
 ## Release 0.9.4
 

--- a/src/main/java/com/dnsimple/exception/BadRequestException.java
+++ b/src/main/java/com/dnsimple/exception/BadRequestException.java
@@ -25,6 +25,6 @@ public class BadRequestException extends DnsimpleException {
 
     @SuppressWarnings("unchecked")
     public Map<String, List<String>> getAttributeErrors() {
-        return ((Map<String, List<String>>) body.getOrDefault("errors", emptyMap()));
+        return (Map<String, List<String>>) body.getOrDefault("errors", emptyMap());
     }
 }

--- a/src/main/java/com/dnsimple/exception/BadRequestException.java
+++ b/src/main/java/com/dnsimple/exception/BadRequestException.java
@@ -2,6 +2,7 @@ package com.dnsimple.exception;
 
 import static java.util.Collections.emptyMap;
 
+import java.util.List;
 import java.util.Map;
 
 public class BadRequestException extends DnsimpleException {
@@ -23,7 +24,7 @@ public class BadRequestException extends DnsimpleException {
     }
 
     @SuppressWarnings("unchecked")
-    public Map<String, Object> getAttributeErrors() {
-        return (Map<String, Object>) body.getOrDefault("errors", emptyMap());
+    public Map<String, List<String>> getAttributeErrors() {
+        return ((Map<String, List<String>>) body.getOrDefault("errors", emptyMap()));
     }
 }

--- a/src/main/java/com/dnsimple/exception/BadRequestException.java
+++ b/src/main/java/com/dnsimple/exception/BadRequestException.java
@@ -1,5 +1,7 @@
 package com.dnsimple.exception;
 
+import static java.util.Collections.emptyMap;
+
 import java.util.Map;
 
 public class BadRequestException extends DnsimpleException {
@@ -18,5 +20,10 @@ public class BadRequestException extends DnsimpleException {
 
     public Map<String, Object> getBody() {
         return body;
+    }
+
+    @SuppressWarnings("unchecked")
+    public Map<String, Object> getAttributeErrors() {
+        return (Map<String, Object>) body.getOrDefault("errors", emptyMap());
     }
 }

--- a/src/test/java/com/dnsimple/ClientTest.java
+++ b/src/test/java/com/dnsimple/ClientTest.java
@@ -41,16 +41,15 @@ public class ClientTest extends DnsimpleTestBase {
             client.contacts.createContact(1, ContactOptions.of("First name", "Last name", "Address 1", "City", "state", "postal", "country", "hello@example.com", "phone"));
         } catch (BadRequestException e) {
             assertThat(e.getBody().get("message"), is("Validation failed"));
-            Map<String, List<String>> errors = (Map<String, List<String>>) e.getBody().get("errors");
-            assertThat(errors.get("address1"), is(singletonList("can't be blank")));
-            assertThat(errors.get("city"), is(singletonList("can't be blank")));
-            assertThat(errors.get("country"), is(singletonList("can't be blank")));
-            assertThat(errors.get("email"), is(List.of("can't be blank", "is an invalid email address")));
-            assertThat(errors.get("first_name"), is(singletonList("can't be blank")));
-            assertThat(errors.get("last_name"), is(singletonList("can't be blank")));
-            assertThat(errors.get("phone"), is(List.of("can't be blank", "is probably not a phone number")));
-            assertThat(errors.get("postal_code"), is(singletonList("can't be blank")));
-            assertThat(errors.get("state_province"), is(singletonList("can't be blank")));
+            assertThat(e.getAttributeErrors().get("address1"), is(singletonList("can't be blank")));
+            assertThat(e.getAttributeErrors().get("city"), is(singletonList("can't be blank")));
+            assertThat(e.getAttributeErrors().get("country"), is(singletonList("can't be blank")));
+            assertThat(e.getAttributeErrors().get("email"), is(List.of("can't be blank", "is an invalid email address")));
+            assertThat(e.getAttributeErrors().get("first_name"), is(singletonList("can't be blank")));
+            assertThat(e.getAttributeErrors().get("last_name"), is(singletonList("can't be blank")));
+            assertThat(e.getAttributeErrors().get("phone"), is(List.of("can't be blank", "is probably not a phone number")));
+            assertThat(e.getAttributeErrors().get("postal_code"), is(singletonList("can't be blank")));
+            assertThat(e.getAttributeErrors().get("state_province"), is(singletonList("can't be blank")));
         }
     }
 }

--- a/src/test/java/com/dnsimple/ClientTest.java
+++ b/src/test/java/com/dnsimple/ClientTest.java
@@ -10,7 +10,6 @@ import com.dnsimple.exception.BadRequestException;
 import com.dnsimple.request.ContactOptions;
 import com.dnsimple.tools.DnsimpleTestBase;
 import java.util.List;
-import java.util.Map;
 import org.junit.Test;
 
 public class ClientTest extends DnsimpleTestBase {


### PR DESCRIPTION
This PR adds a getter for easier and safer access to the attribute errors in the API response