### PR TITLE
Implement signature_algorithm parameter for Let's Encrypt APIs and drop deprecated certificate contact ID support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## main
+
+- BREAKING: `purchaseLetsencryptCertificateRenewal` now takes a `CertificateRenewalPurchaseOptions` object to support the `signatureAlgorithm` field (dnsimple/dnsimple-java#146)
+- NEW: Implement support for `signatureAlgorithm` in `CertificatePurchaseOptions` (dnsimple/dnsimple-java#146)
+
 ## Release 0.9.6
 
 - Update dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## main
 
 - BREAKING: `purchaseLetsencryptCertificateRenewal` now takes a `CertificateRenewalPurchaseOptions` object to support the `signatureAlgorithm` field (dnsimple/dnsimple-java#146)
+- BREAKING: Remove deprecated certificate methods and constructors that use contact ID, which is no longer supported (dnsimple/dnsimple-java#146)
 - NEW: Implement support for `signatureAlgorithm` in `CertificatePurchaseOptions` (dnsimple/dnsimple-java#146)
 
 ## Release 0.9.6

--- a/src/main/java/com/dnsimple/data/Certificate.java
+++ b/src/main/java/com/dnsimple/data/Certificate.java
@@ -6,8 +6,6 @@ import java.util.List;
 public class Certificate {
     private final Long id;
     private final Long domainId;
-    @Deprecated
-    private final Long contactId;
     private final String commonName;
     private final List<String> alternateNames;
     private final Integer years;
@@ -22,27 +20,6 @@ public class Certificate {
     public Certificate(Long id, Long domainId, String commonName, List<String> alternateNames, Integer years, String state, String authorityIdentifier, Boolean autoRenew, OffsetDateTime createdAt, OffsetDateTime updatedAt, OffsetDateTime expiresAt, String csr) {
         this.id = id;
         this.domainId = domainId;
-        this.contactId = null;
-        this.commonName = commonName;
-        this.alternateNames = alternateNames;
-        this.years = years;
-        this.state = state;
-        this.authorityIdentifier = authorityIdentifier;
-        this.autoRenew = autoRenew;
-        this.createdAt = createdAt;
-        this.updatedAt = updatedAt;
-        this.expiresAt = expiresAt;
-        this.csr = csr;
-    }
-
-    /**
-     * @deprecated Please, use a constructor without deprecated arguments
-     */
-    @Deprecated
-    public Certificate(Long id, Long domainId, @Deprecated Long contactId, String commonName, List<String> alternateNames, Integer years, String state, String authorityIdentifier, Boolean autoRenew, OffsetDateTime createdAt, OffsetDateTime updatedAt, OffsetDateTime expiresAt, String csr) {
-        this.id = id;
-        this.domainId = domainId;
-        this.contactId = contactId;
         this.commonName = commonName;
         this.alternateNames = alternateNames;
         this.years = years;
@@ -61,11 +38,6 @@ public class Certificate {
 
     public Long getDomainId() {
         return domainId;
-    }
-
-    @Deprecated
-    public Long getContactId() {
-        return contactId;
     }
 
     public String getCommonName() {

--- a/src/main/java/com/dnsimple/endpoints/Certificates.java
+++ b/src/main/java/com/dnsimple/endpoints/Certificates.java
@@ -6,13 +6,13 @@ import com.dnsimple.data.CertificatePurchase;
 import com.dnsimple.data.CertificateRenewal;
 import com.dnsimple.http.HttpEndpointClient;
 import com.dnsimple.request.CertificatePurchaseOptions;
+import com.dnsimple.request.CertificateRenewalPurchaseOptions;
 import com.dnsimple.request.ListOptions;
 import com.dnsimple.response.PaginatedResponse;
 import com.dnsimple.response.SimpleResponse;
 
 import static com.dnsimple.http.HttpMethod.GET;
 import static com.dnsimple.http.HttpMethod.POST;
-import static java.util.Collections.singletonMap;
 
 /**
  * Provides access to the DNSimple Certificates API.
@@ -131,28 +131,12 @@ public class Certificates {
      * @param account       The account ID
      * @param domain        The domain name or ID
      * @param certificateId The certificate ID
+     * @param options       The options for the certificate renewal
      * @return The Let's Encrypt purchase renewal response
      * @see <a href="https://developer.dnsimple.com/v2/certificates/#purchaseRenewalLetsencryptCertificate">https://developer.dnsimple.com/v2/certificates/#purchaseRenewalLetsencryptCertificate</a>
      */
-    public SimpleResponse<CertificateRenewal> purchaseLetsencryptCertificateRenewal(Number account, String domain, Number certificateId) {
-        return purchaseLetsencryptCertificateRenewal(account, domain, certificateId, false);
-    }
-
-    /**
-     * Purchase a Let's Encrypt certificate renewal.
-     * <p>
-     * This method creates a new renewal order. The order ID should be used to request the issuance of the certificate
-     * using `#issue_letsencrypt_certificate_renewal`.
-     *
-     * @param account       The account ID
-     * @param domain        The domain name or ID
-     * @param certificateId The certificate ID
-     * @param autoRenew     Enable auto-renewal of the certificate
-     * @return The Let's Encrypt purchase renewal response
-     * @see <a href="https://developer.dnsimple.com/v2/certificates/#purchaseRenewalLetsencryptCertificate">https://developer.dnsimple.com/v2/certificates/#purchaseRenewalLetsencryptCertificate</a>
-     */
-    public SimpleResponse<CertificateRenewal> purchaseLetsencryptCertificateRenewal(Number account, String domain, Number certificateId, boolean autoRenew) {
-        return client.simple(POST, account + "/domains/" + domain + "/certificates/letsencrypt/" + certificateId + "/renewals", ListOptions.empty(), singletonMap("auto_renew", autoRenew), CertificateRenewal.class);
+    public SimpleResponse<CertificateRenewal> purchaseLetsencryptCertificateRenewal(Number account, String domain, Number certificateId, CertificateRenewalPurchaseOptions options) {
+        return client.simple(POST, account + "/domains/" + domain + "/certificates/letsencrypt/" + certificateId + "/renewals", ListOptions.empty(), options, CertificateRenewal.class);
     }
 
     /**

--- a/src/main/java/com/dnsimple/request/CertificatePurchaseOptions.java
+++ b/src/main/java/com/dnsimple/request/CertificatePurchaseOptions.java
@@ -9,21 +9,24 @@ public class CertificatePurchaseOptions {
     private final boolean autoRenew;
     private final String name;
     private final List<String> alternateNames;
+    private final SignatureAlgorithm signatureAlgorithm;
 
-    private CertificatePurchaseOptions(boolean autoRenew, String name, List<String> alternateNames) {
+    private CertificatePurchaseOptions(boolean autoRenew, String name, List<String> alternateNames, SignatureAlgorithm signatureAlgorithm) {
         this.autoRenew = autoRenew;
         this.name = name;
         this.alternateNames = alternateNames;
+        this.signatureAlgorithm = signatureAlgorithm;
     }
 
     /**
      * @deprecated Please, use a constructor without deprecated arguments
      */
     @Deprecated
-    private CertificatePurchaseOptions(@Deprecated Long contactId, boolean autoRenew, String name, List<String> alternateNames) {
+    private CertificatePurchaseOptions(@Deprecated Long contactId, boolean autoRenew, String name, List<String> alternateNames, SignatureAlgorithm signatureAlgorithm) {
         this.autoRenew = autoRenew;
         this.name = name;
         this.alternateNames = alternateNames;
+        this.signatureAlgorithm = signatureAlgorithm;
     }
 
 
@@ -33,21 +36,21 @@ public class CertificatePurchaseOptions {
      */
     @Deprecated
     public static CertificatePurchaseOptions of(@Deprecated Number contactId) {
-        return new CertificatePurchaseOptions(false, "www", emptyList());
+        return new CertificatePurchaseOptions(false, "www", emptyList(), SignatureAlgorithm.ECDSA);
     }
 
     /**
      * @param name The name of the certificate to be requested
      */
     public static CertificatePurchaseOptions of(String name) {
-        return new CertificatePurchaseOptions(false, name, emptyList());
+        return new CertificatePurchaseOptions(false, name, emptyList(), SignatureAlgorithm.ECDSA);
     }
 
     /**
      * Enable auto-renew for the certificate
      */
     public CertificatePurchaseOptions autoRenew() {
-        return new CertificatePurchaseOptions(true, name, alternateNames);
+        return new CertificatePurchaseOptions(true, name, alternateNames, SignatureAlgorithm.ECDSA);
     }
 
     /**
@@ -55,13 +58,20 @@ public class CertificatePurchaseOptions {
      */
     @Deprecated
     public CertificatePurchaseOptions name(String name) {
-        return new CertificatePurchaseOptions(autoRenew, name, alternateNames);
+        return new CertificatePurchaseOptions(autoRenew, name, alternateNames, SignatureAlgorithm.ECDSA);
     }
 
     /**
      * Set alternate names for the certificate
      */
     public CertificatePurchaseOptions alternateNames(String... names) {
-        return new CertificatePurchaseOptions(autoRenew, name, Arrays.asList(names));
+        return new CertificatePurchaseOptions(autoRenew, name, Arrays.asList(names), SignatureAlgorithm.ECDSA);
+    }
+
+    /**
+     * Set the signature algorithm for the certificate
+     */
+    public CertificatePurchaseOptions signatureAlgorithm(SignatureAlgorithm signatureAlgorithm) {
+        return new CertificatePurchaseOptions(autoRenew, name, alternateNames, signatureAlgorithm);
     }
 }

--- a/src/main/java/com/dnsimple/request/CertificatePurchaseOptions.java
+++ b/src/main/java/com/dnsimple/request/CertificatePurchaseOptions.java
@@ -50,7 +50,7 @@ public class CertificatePurchaseOptions {
      * Enable auto-renew for the certificate
      */
     public CertificatePurchaseOptions autoRenew() {
-        return new CertificatePurchaseOptions(true, name, alternateNames, SignatureAlgorithm.ECDSA);
+        return new CertificatePurchaseOptions(true, name, alternateNames, signatureAlgorithm);
     }
 
     /**
@@ -58,14 +58,14 @@ public class CertificatePurchaseOptions {
      */
     @Deprecated
     public CertificatePurchaseOptions name(String name) {
-        return new CertificatePurchaseOptions(autoRenew, name, alternateNames, SignatureAlgorithm.ECDSA);
+        return new CertificatePurchaseOptions(autoRenew, name, alternateNames, signatureAlgorithm);
     }
 
     /**
      * Set alternate names for the certificate
      */
     public CertificatePurchaseOptions alternateNames(String... names) {
-        return new CertificatePurchaseOptions(autoRenew, name, Arrays.asList(names), SignatureAlgorithm.ECDSA);
+        return new CertificatePurchaseOptions(autoRenew, name, Arrays.asList(names), signatureAlgorithm);
     }
 
     /**

--- a/src/main/java/com/dnsimple/request/CertificatePurchaseOptions.java
+++ b/src/main/java/com/dnsimple/request/CertificatePurchaseOptions.java
@@ -19,27 +19,6 @@ public class CertificatePurchaseOptions {
     }
 
     /**
-     * @deprecated Please, use a constructor without deprecated arguments
-     */
-    @Deprecated
-    private CertificatePurchaseOptions(@Deprecated Long contactId, boolean autoRenew, String name, List<String> alternateNames, SignatureAlgorithm signatureAlgorithm) {
-        this.autoRenew = autoRenew;
-        this.name = name;
-        this.alternateNames = alternateNames;
-        this.signatureAlgorithm = signatureAlgorithm;
-    }
-
-
-    /**
-     * @param contactId This argument has been deprecated and is ignored in upstream API requests
-     * @deprecated Please, use the class constructor instead
-     */
-    @Deprecated
-    public static CertificatePurchaseOptions of(@Deprecated Number contactId) {
-        return new CertificatePurchaseOptions(false, "www", emptyList(), SignatureAlgorithm.ECDSA);
-    }
-
-    /**
      * @param name The name of the certificate to be requested
      */
     public static CertificatePurchaseOptions of(String name) {
@@ -51,14 +30,6 @@ public class CertificatePurchaseOptions {
      */
     public CertificatePurchaseOptions autoRenew() {
         return new CertificatePurchaseOptions(true, name, alternateNames, signatureAlgorithm);
-    }
-
-    /**
-     * @deprecated Please, use the {@link #of(String)} factory method instead
-     */
-    @Deprecated
-    public CertificatePurchaseOptions name(String name) {
-        return new CertificatePurchaseOptions(autoRenew, name, alternateNames, signatureAlgorithm);
     }
 
     /**

--- a/src/main/java/com/dnsimple/request/CertificateRenewalPurchaseOptions.java
+++ b/src/main/java/com/dnsimple/request/CertificateRenewalPurchaseOptions.java
@@ -1,0 +1,32 @@
+package com.dnsimple.request;
+
+public class CertificateRenewalPurchaseOptions {
+    private final boolean autoRenew;
+    private final SignatureAlgorithm signatureAlgorithm;
+
+    private CertificateRenewalPurchaseOptions(boolean autoRenew, SignatureAlgorithm signatureAlgorithm) {
+        this.autoRenew = autoRenew;
+        this.signatureAlgorithm = signatureAlgorithm;
+    }
+
+    /**
+     * @param name The name of the certificate to be renewed
+     */
+    public static CertificateRenewalPurchaseOptions of(String name) {
+        return new CertificateRenewalPurchaseOptions(false, SignatureAlgorithm.ECDSA);
+    }
+
+    /**
+     * Enable auto-renew for the certificate
+     */
+    public CertificateRenewalPurchaseOptions autoRenew() {
+        return new CertificateRenewalPurchaseOptions(true, signatureAlgorithm);
+    }
+
+    /**
+     * Set the signature algorithm for the certificate
+     */
+    public CertificateRenewalPurchaseOptions signatureAlgorithm(SignatureAlgorithm signatureAlgorithm) {
+        return new CertificateRenewalPurchaseOptions(autoRenew, signatureAlgorithm);
+    }
+}

--- a/src/main/java/com/dnsimple/request/CertificateRenewalPurchaseOptions.java
+++ b/src/main/java/com/dnsimple/request/CertificateRenewalPurchaseOptions.java
@@ -9,10 +9,7 @@ public class CertificateRenewalPurchaseOptions {
         this.signatureAlgorithm = signatureAlgorithm;
     }
 
-    /**
-     * @param name The name of the certificate to be renewed
-     */
-    public static CertificateRenewalPurchaseOptions of(String name) {
+    public static CertificateRenewalPurchaseOptions empty() {
         return new CertificateRenewalPurchaseOptions(false, SignatureAlgorithm.ECDSA);
     }
 

--- a/src/main/java/com/dnsimple/request/SignatureAlgorithm.java
+++ b/src/main/java/com/dnsimple/request/SignatureAlgorithm.java
@@ -1,0 +1,6 @@
+package com.dnsimple.request;
+
+public enum SignatureAlgorithm {
+  ECDSA,
+  RSA,
+}

--- a/src/test/java/com/dnsimple/endpoints/CertificatesTest.java
+++ b/src/test/java/com/dnsimple/endpoints/CertificatesTest.java
@@ -7,6 +7,7 @@ import com.dnsimple.data.CertificateRenewal;
 import com.dnsimple.exception.ResourceNotFoundException;
 import com.dnsimple.request.CertificatePurchaseOptions;
 import com.dnsimple.request.ListOptions;
+import com.dnsimple.request.SignatureAlgorithm;
 import com.dnsimple.response.PaginatedResponse;
 import com.dnsimple.response.SimpleResponse;
 import com.dnsimple.tools.DnsimpleTestBase;
@@ -216,7 +217,7 @@ public class CertificatesTest extends DnsimpleTestBase {
     @SuppressWarnings("unchecked")
     public void testPurchaseLetsencryptCertificate() {
         server.stubFixtureAt("purchaseLetsencryptCertificate/success.http");
-        CertificatePurchaseOptions options = CertificatePurchaseOptions.of("www").autoRenew().alternateNames("web", "theweb");
+        CertificatePurchaseOptions options = CertificatePurchaseOptions.of("www").autoRenew().alternateNames("web", "theweb").signatureAlgorithm(SignatureAlgorithm.ECDSA);
         SimpleResponse<CertificatePurchase> response = client.certificates.purchaseLetsencryptCertificate(1010, "bingo.pizza", options);
         assertThat(server.getRecordedRequest().getMethod(), is(POST));
         assertThat(server.getRecordedRequest().getPath(), is("/v2/1010/domains/bingo.pizza/certificates/letsencrypt"));

--- a/src/test/java/com/dnsimple/endpoints/CertificatesTest.java
+++ b/src/test/java/com/dnsimple/endpoints/CertificatesTest.java
@@ -259,7 +259,7 @@ public class CertificatesTest extends DnsimpleTestBase {
     @Test
     public void testPurchaseLetsencryptCertificateRenewal() {
         server.stubFixtureAt("purchaseRenewalLetsencryptCertificate/success.http");
-        SimpleResponse<CertificateRenewal> response = client.certificates.purchaseLetsencryptCertificateRenewal(1010, "bingo.pizza", 101967, CertificateRenewalPurchaseOptions.of("www").autoRenew().signatureAlgorithm(SignatureAlgorithm.RSA));
+        SimpleResponse<CertificateRenewal> response = client.certificates.purchaseLetsencryptCertificateRenewal(1010, "bingo.pizza", 101967, CertificateRenewalPurchaseOptions.empty().autoRenew().signatureAlgorithm(SignatureAlgorithm.RSA));
         assertThat(server.getRecordedRequest().getMethod(), is(POST));
         assertThat(server.getRecordedRequest().getPath(), is("/v2/1010/domains/bingo.pizza/certificates/letsencrypt/101967/renewals"));
         assertThat(server.getRecordedRequest().getJsonObjectPayload(), hasEntry("auto_renew", true));

--- a/src/test/java/com/dnsimple/endpoints/CertificatesTest.java
+++ b/src/test/java/com/dnsimple/endpoints/CertificatesTest.java
@@ -6,6 +6,7 @@ import com.dnsimple.data.CertificatePurchase;
 import com.dnsimple.data.CertificateRenewal;
 import com.dnsimple.exception.ResourceNotFoundException;
 import com.dnsimple.request.CertificatePurchaseOptions;
+import com.dnsimple.request.CertificateRenewalPurchaseOptions;
 import com.dnsimple.request.ListOptions;
 import com.dnsimple.request.SignatureAlgorithm;
 import com.dnsimple.response.PaginatedResponse;
@@ -258,7 +259,7 @@ public class CertificatesTest extends DnsimpleTestBase {
     @Test
     public void testPurchaseLetsencryptCertificateRenewal() {
         server.stubFixtureAt("purchaseRenewalLetsencryptCertificate/success.http");
-        SimpleResponse<CertificateRenewal> response = client.certificates.purchaseLetsencryptCertificateRenewal(1010, "bingo.pizza", 101967, true);
+        SimpleResponse<CertificateRenewal> response = client.certificates.purchaseLetsencryptCertificateRenewal(1010, "bingo.pizza", 101967, CertificateRenewalPurchaseOptions.of("www").autoRenew().signatureAlgorithm(SignatureAlgorithm.RSA));
         assertThat(server.getRecordedRequest().getMethod(), is(POST));
         assertThat(server.getRecordedRequest().getPath(), is("/v2/1010/domains/bingo.pizza/certificates/letsencrypt/101967/renewals"));
         assertThat(server.getRecordedRequest().getJsonObjectPayload(), hasEntry("auto_renew", true));


### PR DESCRIPTION
Add the `signature_algorithm` parameter for `CertificatePurchaseOptions`.

Drop constructors, fields, and methods related to certificate contact ID.