### PR TITLE
Create CertificatePrivateKey class instead of combining into CertificateBundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## main
 
+BREAKING CHANGES
+
+- `CertificateBundle.privateKey` has been moved to its own class called `CertificatePrivateKey`, which is now returned by `Certificates::getCertificatePrivateKey`. (dnsimple/dnsimple-java#150)
+
 ## 0.14.0
 
 ENHANCEMENTS:

--- a/src/main/java/com/dnsimple/data/CertificateBundle.java
+++ b/src/main/java/com/dnsimple/data/CertificateBundle.java
@@ -3,31 +3,25 @@ package com.dnsimple.data;
 import java.util.List;
 
 public class CertificateBundle {
-    private final String privateKey;
     private final String server;
     private final String root;
     private final List<String> chain;
 
-    public CertificateBundle(String privateKey, String server, String root, List<String> chain) {
-        this.privateKey = privateKey;
+    public CertificateBundle(String server, String root, List<String> chain) {
         this.server = server;
         this.root = root;
         this.chain = chain;
     }
 
-    public String getPrivateKey() {
-        return privateKey;
-    }
-
-    public String getServerCertificate() {
+    public String getServer() {
         return server;
     }
 
-    public String getRootCertificate() {
+    public String getRoot() {
         return root;
     }
 
-    public List<String> getIntermediateCertificates() {
+    public List<String> getChain() {
         return chain;
     }
 }

--- a/src/main/java/com/dnsimple/data/CertificatePrivateKey.java
+++ b/src/main/java/com/dnsimple/data/CertificatePrivateKey.java
@@ -1,0 +1,13 @@
+package com.dnsimple.data;
+
+public class CertificatePrivateKey {
+    private final String privateKey;
+
+    public CertificatePrivateKey(String privateKey) {
+        this.privateKey = privateKey;
+    }
+
+    public String getPrivateKey() {
+        return privateKey;
+    }
+}

--- a/src/main/java/com/dnsimple/endpoints/Certificates.java
+++ b/src/main/java/com/dnsimple/endpoints/Certificates.java
@@ -1,9 +1,6 @@
 package com.dnsimple.endpoints;
 
-import com.dnsimple.data.Certificate;
-import com.dnsimple.data.CertificateBundle;
-import com.dnsimple.data.CertificatePurchase;
-import com.dnsimple.data.CertificateRenewal;
+import com.dnsimple.data.*;
 import com.dnsimple.http.HttpEndpointClient;
 import com.dnsimple.request.CertificatePurchaseOptions;
 import com.dnsimple.request.CertificateRenewalPurchaseOptions;
@@ -86,8 +83,8 @@ public class Certificates {
      * @return The get certificate private key response
      * @see <a href="https://developer.dnsimple.com/v2/certificates/#getCertificatePrivateKey">https://developer.dnsimple.com/v2/certificates/#getCertificatePrivateKey</a>
      */
-    public SimpleResponse<CertificateBundle> getCertificatePrivateKey(Number account, String domain, Number certificateId) {
-        return client.simple(GET, account + "/domains/" + domain + "/certificates/" + certificateId + "/private_key", ListOptions.empty(), null, CertificateBundle.class);
+    public SimpleResponse<CertificatePrivateKey> getCertificatePrivateKey(Number account, String domain, Number certificateId) {
+        return client.simple(GET, account + "/domains/" + domain + "/certificates/" + certificateId + "/private_key", ListOptions.empty(), null, CertificatePrivateKey.class);
     }
 
     /**

--- a/src/test/java/com/dnsimple/endpoints/CertificatesTest.java
+++ b/src/test/java/com/dnsimple/endpoints/CertificatesTest.java
@@ -1,9 +1,6 @@
 package com.dnsimple.endpoints;
 
-import com.dnsimple.data.Certificate;
-import com.dnsimple.data.CertificateBundle;
-import com.dnsimple.data.CertificatePurchase;
-import com.dnsimple.data.CertificateRenewal;
+import com.dnsimple.data.*;
 import com.dnsimple.exception.ResourceNotFoundException;
 import com.dnsimple.request.CertificatePurchaseOptions;
 import com.dnsimple.request.CertificateRenewalPurchaseOptions;
@@ -114,8 +111,7 @@ public class CertificatesTest extends DnsimpleTestBase {
         assertThat(server.getRecordedRequest().getMethod(), is(GET));
         assertThat(server.getRecordedRequest().getPath(), is("/v2/1010/domains/weppos.net/certificates/1/download"));
         CertificateBundle certificateBundle = response.getData();
-        assertThat(certificateBundle.getPrivateKey(), is(nullValue()));
-        assertThat(certificateBundle.getServerCertificate(), is("" +
+        assertThat(certificateBundle.getServer(), is("" +
                 "-----BEGIN CERTIFICATE-----\n" +
                 "MIIE7TCCA9WgAwIBAgITAPpTe4O3vjuQ9L4gLsogi/ukujANBgkqhkiG9w0BAQsF\n" +
                 "ADAiMSAwHgYDVQQDDBdGYWtlIExFIEludGVybWVkaWF0ZSBYMTAeFw0xNjA2MTEx\n" +
@@ -145,9 +141,9 @@ public class CertificatesTest extends DnsimpleTestBase {
                 "tQaemFWTjGPgSLXJAtQO30DgNJBHX/fJEaHv6Wy8TF3J0wOGpzGbOwaTX8YAmEzC\n" +
                 "lzzjs+clg5MN5rd1g4POJtU=\n" +
                 "-----END CERTIFICATE-----\n"));
-        assertThat(certificateBundle.getRootCertificate(), is(isEmptyOrNullString()));
-        assertThat(certificateBundle.getIntermediateCertificates(), hasSize(1));
-        assertThat(certificateBundle.getIntermediateCertificates().get(0), is("" +
+        assertThat(certificateBundle.getRoot(), is(isEmptyOrNullString()));
+        assertThat(certificateBundle.getChain(), hasSize(1));
+        assertThat(certificateBundle.getChain().get(0), is("" +
                 "-----BEGIN CERTIFICATE-----\n" +
                 "MIIEqzCCApOgAwIBAgIRAIvhKg5ZRO08VGQx8JdhT+UwDQYJKoZIhvcNAQELBQAw\n" +
                 "GjEYMBYGA1UEAwwPRmFrZSBMRSBSb290IFgxMB4XDTE2MDUyMzIyMDc1OVoXDTM2\n" +
@@ -180,11 +176,11 @@ public class CertificatesTest extends DnsimpleTestBase {
     @Test
     public void testCertificatePrivateKey() {
         server.stubFixtureAt("getCertificatePrivateKey/success.http");
-        SimpleResponse<CertificateBundle> response = client.certificates.getCertificatePrivateKey(1010, "weppos.net", 1);
+        SimpleResponse<CertificatePrivateKey> response = client.certificates.getCertificatePrivateKey(1010, "weppos.net", 1);
         assertThat(server.getRecordedRequest().getMethod(), is(GET));
         assertThat(server.getRecordedRequest().getPath(), is("/v2/1010/domains/weppos.net/certificates/1/private_key"));
-        CertificateBundle certificateBundle = response.getData();
-        assertThat(certificateBundle.getPrivateKey(), is("" +
+        CertificatePrivateKey certificatePrivateKey = response.getData();
+        assertThat(certificatePrivateKey.getPrivateKey(), is("" +
                 "-----BEGIN RSA PRIVATE KEY-----\n" +
                 "MIIEowIBAAKCAQEAtzCcMfWoQRt5AMEY0HUb2GaraL1GsWOo6YXdPfe+YDvtnmDw\n" +
                 "23NcoTX7VSeCgU9M3RKs19AsCJcRNTLJ2dmDrAuyCTud9YTAaXQcTOLUhtO8T8+9\n" +


### PR DESCRIPTION
Currently, we return CertificateBundle for both downloadCertificate and getCertificatePrivateKey, despite not having any shared data. Move the private key data into its own class. This is a breaking change. Fixes #118. We'll postpone merging until the next major version; if we merge it now, our next release must be breaking, even if the other changes are only patches or minor.