### PR TITLE
Add support to activate and deactivate DNS services for a zone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## main
+
+## 0.11.0 (Unreleased)
+
+FEATURES:
+
+- NEW: Added `Dnsimple.Zones.activateDns` to activate DNS services (resolution) for a zone. (dnsimple/dnsimple-java#157)
+- NEW: Added `Dnsimple.Zones.deactivateDns` to deactivate DNS services (resolution) for a zone. (dnsimple/dnsimple-java#157)
+
 ## Release 0.10.0
 
 - BREAKING: `purchaseLetsencryptCertificateRenewal` now takes a `CertificateRenewalPurchaseOptions` object to support the `signatureAlgorithm` field (dnsimple/dnsimple-java#146)

--- a/src/main/java/com/dnsimple/endpoints/Domains.java
+++ b/src/main/java/com/dnsimple/endpoints/Domains.java
@@ -268,17 +268,17 @@ public class Domains {
     /**
      * Create an email forward for a domain.
      *
-     * @param account The account ID
-     * @param domain  The domain name or ID
-     * @param from    The email address the emails are send to
-     * @param to      The email address the email address the emails are forwarded to.
+     * @param account          The account ID
+     * @param domain           The domain name or ID
+     * @param aliasEmail       The email address the emails are send to
+     * @param destinationEmail The email address the email address the emails are forwarded to.
      * @return The create email forward response
      * @see <a href="https://developer.dnsimple.com/v2/domains/email-forwards/#createEmailForward">https://developer.dnsimple.com/v2/domains/email-forwards/#createEmailForward</a>
      */
-    public SimpleResponse<EmailForward> createEmailForward(Number account, String domain, String from, String to) {
+    public SimpleResponse<EmailForward> createEmailForward(Number account, String domain, String aliasEmail, String destinationEmail) {
         Map<String, String> options = new HashMap<>();
-        options.put("from", from);
-        options.put("to", to);
+        options.put("alias_email", aliasEmail);
+        options.put("destination_email", destinationEmail);
         return client.simple(POST, account + "/domains/" + domain + "/email_forwards", ListOptions.empty(), options, EmailForward.class);
     }
 

--- a/src/main/java/com/dnsimple/endpoints/Domains.java
+++ b/src/main/java/com/dnsimple/endpoints/Domains.java
@@ -270,14 +270,14 @@ public class Domains {
      *
      * @param account          The account ID
      * @param domain           The domain name or ID
-     * @param aliasEmail       The email address the emails are send to
+     * @param aliasName        The email address the emails are send to
      * @param destinationEmail The email address the email address the emails are forwarded to.
      * @return The create email forward response
      * @see <a href="https://developer.dnsimple.com/v2/domains/email-forwards/#createEmailForward">https://developer.dnsimple.com/v2/domains/email-forwards/#createEmailForward</a>
      */
-    public SimpleResponse<EmailForward> createEmailForward(Number account, String domain, String aliasEmail, String destinationEmail) {
+    public SimpleResponse<EmailForward> createEmailForward(Number account, String domain, String aliasName, String destinationEmail) {
         Map<String, String> options = new HashMap<>();
-        options.put("alias_email", aliasEmail);
+        options.put("alias_name", aliasName);
         options.put("destination_email", destinationEmail);
         return client.simple(POST, account + "/domains/" + domain + "/email_forwards", ListOptions.empty(), options, EmailForward.class);
     }

--- a/src/main/java/com/dnsimple/endpoints/Zones.java
+++ b/src/main/java/com/dnsimple/endpoints/Zones.java
@@ -27,6 +27,30 @@ public class Zones {
     }
 
     /**
+     * Activate DNS resolution for the zone in the account.
+     *
+     * @param account The account ID
+     * @param zoneName The zone name
+     * @return The zone
+     * @see <a href="https://developer.dnsimple.com/v2/zones/#activateZoneService">https://developer.dnsimple.com/v2/zones/#activateZoneService</a>
+     */
+    public SimpleResponse<Zone> activateDns(Number account, String zoneName) {
+        return client.simple(PUT, account + "/zones/" + zoneName + "/activation", ListOptions.empty(), null, Zone.class);
+    }
+
+    /**
+     * Deactivate DNS resolution for the zone in the account.
+     *
+     * @param account The account ID
+     * @param zoneName The zone name
+     * @return The zone
+     * @see <a href="https://developer.dnsimple.com/v2/zones/#deactivateZoneService">https://developer.dnsimple.com/v2/zones/#deactivateZoneService</a>
+     */
+    public SimpleResponse<Zone> deactivateDns(Number account, String zoneName) {
+        return client.simple(DELETE, account + "/zones/" + zoneName + "/activation", ListOptions.empty(), null, Zone.class);
+    }
+
+    /**
      * Lists the zones in the account.
      *
      * @param account The account ID

--- a/src/test/java/com/dnsimple/endpoints/DomainEmailForwardsTest.java
+++ b/src/test/java/com/dnsimple/endpoints/DomainEmailForwardsTest.java
@@ -85,8 +85,8 @@ public class DomainEmailForwardsTest extends DnsimpleTestBase {
         server.stubFixtureAt("createEmailForward/created.http");
         SimpleResponse<EmailForward> response = client.domains.createEmailForward(1, "example.com", "example@dnsimple.xyz", "example@example.com");
         assertThat(server.getRecordedRequest().getJsonObjectPayload(), allOf(
-                hasEntry("from", "example@dnsimple.xyz"),
-                hasEntry("to", "example@example.com")
+                hasEntry("alias_email", "example@dnsimple.xyz"),
+                hasEntry("destination_email", "example@example.com")
         ));
         assertThat(response.getData().getId(), is(41872L));
     }

--- a/src/test/java/com/dnsimple/endpoints/DomainEmailForwardsTest.java
+++ b/src/test/java/com/dnsimple/endpoints/DomainEmailForwardsTest.java
@@ -85,7 +85,7 @@ public class DomainEmailForwardsTest extends DnsimpleTestBase {
         server.stubFixtureAt("createEmailForward/created.http");
         SimpleResponse<EmailForward> response = client.domains.createEmailForward(1, "example.com", "example@dnsimple.xyz", "example@example.com");
         assertThat(server.getRecordedRequest().getJsonObjectPayload(), allOf(
-                hasEntry("alias_email", "example@dnsimple.xyz"),
+                hasEntry("alias_name", "example@dnsimple.xyz"),
                 hasEntry("destination_email", "example@example.com")
         ));
         assertThat(response.getData().getId(), is(41872L));

--- a/src/test/java/com/dnsimple/endpoints/DomainsTest.java
+++ b/src/test/java/com/dnsimple/endpoints/DomainsTest.java
@@ -19,13 +19,6 @@ import static org.hamcrest.Matchers.*;
 
 public class DomainsTest extends DnsimpleTestBase {
     @Test
-    public void testActivateDns() {
-        client.domains.listDomains(1, ListOptions.empty().page(1));
-        assertThat(server.getRecordedRequest().getMethod(), is(GET));
-        assertThat(server.getRecordedRequest().getPath(), is("/v2/1/domains?page=1"));
-    }
-
-    @Test
     public void testListDomainsSupportsPagination() {
         client.domains.listDomains(1, ListOptions.empty().page(1));
         assertThat(server.getRecordedRequest().getMethod(), is(GET));

--- a/src/test/java/com/dnsimple/endpoints/DomainsTest.java
+++ b/src/test/java/com/dnsimple/endpoints/DomainsTest.java
@@ -19,6 +19,13 @@ import static org.hamcrest.Matchers.*;
 
 public class DomainsTest extends DnsimpleTestBase {
     @Test
+    public void testActivateDns() {
+        client.domains.listDomains(1, ListOptions.empty().page(1));
+        assertThat(server.getRecordedRequest().getMethod(), is(GET));
+        assertThat(server.getRecordedRequest().getPath(), is("/v2/1/domains?page=1"));
+    }
+
+    @Test
     public void testListDomainsSupportsPagination() {
         client.domains.listDomains(1, ListOptions.empty().page(1));
         assertThat(server.getRecordedRequest().getMethod(), is(GET));

--- a/src/test/java/com/dnsimple/endpoints/ZonesTest.java
+++ b/src/test/java/com/dnsimple/endpoints/ZonesTest.java
@@ -22,6 +22,30 @@ import static org.hamcrest.Matchers.*;
 
 public class ZonesTest extends DnsimpleTestBase {
     @Test
+    public void testActivateDns() {
+        server.stubFixtureAt("activateZoneService/success.http");
+        Zone z = client.zones.activateDns(1010, "example.com").getData();
+        assertThat(z.getId(), is(1L));
+        assertThat(z.getAccountId(), is(1010L));
+        assertThat(z.getName(), is("example.com"));
+        assertThat(z.isReverse(), is(false));
+        assertThat(zone.getCreatedAt(), is(OffsetDateTime.of(2015, 4, 23, 7, 40, 3, 0, ZoneOffset.UTC)));
+        assertThat(zone.getUpdatedAt(), is(OffsetDateTime.of(2015, 4, 23, 7, 40, 3, 0, ZoneOffset.UTC)));
+    }
+
+    @Test
+    public void testDeactivateDns() {
+        server.stubFixtureAt("deactivateZoneService/success.http");
+        Zone z = client.zones.deactivateDns(1010, "example.com").getData();
+        assertThat(z.getId(), is(1L));
+        assertThat(z.getAccountId(), is(1010L));
+        assertThat(z.getName(), is("example.com"));
+        assertThat(z.isReverse(), is(false));
+        assertThat(zone.getCreatedAt(), is(OffsetDateTime.of(2015, 4, 23, 7, 40, 3, 0, ZoneOffset.UTC)));
+        assertThat(zone.getUpdatedAt(), is(OffsetDateTime.of(2015, 4, 23, 7, 40, 3, 0, ZoneOffset.UTC)));
+    }
+
+    @Test
     public void testListZonesSupportsPagination() {
         client.zones.listZones(1, ListOptions.empty().page(1));
         assertThat(server.getRecordedRequest().getMethod(), is(GET));

--- a/src/test/java/com/dnsimple/endpoints/ZonesTest.java
+++ b/src/test/java/com/dnsimple/endpoints/ZonesTest.java
@@ -29,8 +29,8 @@ public class ZonesTest extends DnsimpleTestBase {
         assertThat(z.getAccountId(), is(1010L));
         assertThat(z.getName(), is("example.com"));
         assertThat(z.isReverse(), is(false));
-        assertThat(zone.getCreatedAt(), is(OffsetDateTime.of(2015, 4, 23, 7, 40, 3, 0, ZoneOffset.UTC)));
-        assertThat(zone.getUpdatedAt(), is(OffsetDateTime.of(2015, 4, 23, 7, 40, 3, 0, ZoneOffset.UTC)));
+        assertThat(z.getCreatedAt(), is(OffsetDateTime.of(2015, 4, 23, 7, 40, 3, 0, ZoneOffset.UTC)));
+        assertThat(z.getUpdatedAt(), is(OffsetDateTime.of(2015, 4, 23, 7, 40, 3, 0, ZoneOffset.UTC)));
     }
 
     @Test
@@ -41,8 +41,8 @@ public class ZonesTest extends DnsimpleTestBase {
         assertThat(z.getAccountId(), is(1010L));
         assertThat(z.getName(), is("example.com"));
         assertThat(z.isReverse(), is(false));
-        assertThat(zone.getCreatedAt(), is(OffsetDateTime.of(2015, 4, 23, 7, 40, 3, 0, ZoneOffset.UTC)));
-        assertThat(zone.getUpdatedAt(), is(OffsetDateTime.of(2015, 4, 23, 7, 40, 3, 0, ZoneOffset.UTC)));
+        assertThat(z.getCreatedAt(), is(OffsetDateTime.of(2015, 4, 23, 7, 40, 3, 0, ZoneOffset.UTC)));
+        assertThat(z.getUpdatedAt(), is(OffsetDateTime.of(2015, 4, 23, 7, 40, 3, 0, ZoneOffset.UTC)));
     }
 
     @Test

--- a/src/test/resources/com/dnsimple/activateZoneService/success.http
+++ b/src/test/resources/com/dnsimple/activateZoneService/success.http
@@ -1,0 +1,16 @@
+HTTP/1.1 200 OK
+Server: nginx
+Date: Tue, 08 Aug 2023 04:19:23 GMT
+Content-Type: application/json; charset=utf-8
+Connection: keep-alive
+X-RateLimit-Limit: 2400
+X-RateLimit-Remaining: 2399
+X-RateLimit-Reset: 1691471963
+X-WORK-WITH-US: Love automation? So do we! https://dnsimple.com/jobs
+ETag: W/"fe6afd982459be33146933235343d51d"
+Cache-Control: max-age=0, private, must-revalidate
+X-Request-Id: 8e8ac535-9f46-4304-8440-8c68c30427c3
+X-Runtime: 0.176579
+Strict-Transport-Security: max-age=63072000
+
+{"data":{"id":1,"account_id":1010,"name":"example.com","reverse":false,"secondary":false,"last_transferred_at":null,"active":true,"created_at":"2015-04-23T07:40:03Z","updated_at":"2015-04-23T07:40:03Z"}}

--- a/src/test/resources/com/dnsimple/deactivateZoneService/success.http
+++ b/src/test/resources/com/dnsimple/deactivateZoneService/success.http
@@ -1,0 +1,16 @@
+HTTP/1.1 200 OK
+Server: nginx
+Date: Tue, 08 Aug 2023 04:19:52 GMT
+Content-Type: application/json; charset=utf-8
+Connection: keep-alive
+X-RateLimit-Limit: 2400
+X-RateLimit-Remaining: 2398
+X-RateLimit-Reset: 1691471962
+X-WORK-WITH-US: Love automation? So do we! https://dnsimple.com/jobs
+ETag: W/"5f30a37d01b99bb9e620ef1bbce9a014"
+Cache-Control: max-age=0, private, must-revalidate
+X-Request-Id: d2f7bba4-4c81-4818-81d2-c9bbe95f104e
+X-Runtime: 0.133278
+Strict-Transport-Security: max-age=63072000
+
+{"data":{"id":1,"account_id":1010,"name":"example.com","reverse":false,"secondary":false,"last_transferred_at":null,"active":false,"created_at":"2015-04-23T07:40:03Z","updated_at":"2015-04-23T07:40:03Z"}}


### PR DESCRIPTION
This PR implements https://github.com/dnsimple/dnsimple-developer/pull/502 which allows for the management of DNS resolution for a particular zone.

Belongs to https://github.com/dnsimple/dnsimple-external-integrations/issues/3
Belongs to https://github.com/dnsimple/dnsimple-external-integrations/issues/2