### PR TITLE
Add support for registrant APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## main
 
-## 0.11.1 (Unreleased)
+## 0.12.0 (Unreleased)
 
 FEATURES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## main
 
+## 0.11.1 (Unreleased)
+
+FEATURES:
+
+- NEW: Added `Dnsimple.Registrar.createRegistrantChange` to start a registrant change. (dnsimple/dnsimple-java#159)
+
 ## 0.11.0
 
 FEATURES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 FEATURES:
 
-- NEW: Added `Dnsimple.Registrar.createRegistrantChange` to start a registrant change. (dnsimple/dnsimple-java#159)
+- NEW: Added `listRegistrantChanges`, `createRegistrantChange`, `checkRegistrantChange`, `getRegistrantChange`, and `deleteRegistrantChange` methods to `Registrar` to manage registrant changes. (dnsimple/dnsimple-java#159)
 
 ## 0.11.0
 

--- a/src/main/java/com/dnsimple/data/RegistrantChange.java
+++ b/src/main/java/com/dnsimple/data/RegistrantChange.java
@@ -1,10 +1,10 @@
 package com.dnsimple.data;
 
 import java.util.Map;
+import java.util.Objects;
 
 public class RegistrantChange {
     private final Long id;
-    private final Long type;
     private final Long accountId;
     private final Long contactId;
     private final Long domainId;
@@ -15,9 +15,8 @@ public class RegistrantChange {
     private final String createdAt;
     private final String updatedAt;
 
-    public RegistrantChange(Long id, Long type, Long accountId, Long contactId, Long domainId, String state, Map<String, String> extendedAttributes, Boolean registryOwnerChange, String irtLockLiftedBy, String createdAt, String updatedAt) {
+    public RegistrantChange(Long id, Long accountId, Long contactId, Long domainId, String state, Map<String, String> extendedAttributes, Boolean registryOwnerChange, String irtLockLiftedBy, String createdAt, String updatedAt) {
         this.id = id;
-        this.type = type;
         this.accountId = accountId;
         this.contactId = contactId;
         this.domainId = domainId;
@@ -31,10 +30,6 @@ public class RegistrantChange {
 
     public Long getId() {
         return id;
-    }
-
-    public Long getType() {
-        return type;
     }
 
     public Long getAccountId() {
@@ -71,5 +66,18 @@ public class RegistrantChange {
 
     public String getUpdatedAt() {
         return updatedAt;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        RegistrantChange that = (RegistrantChange) o;
+        return Objects.equals(id, that.id) && Objects.equals(accountId, that.accountId) && Objects.equals(contactId, that.contactId) && Objects.equals(domainId, that.domainId) && Objects.equals(state, that.state) && Objects.equals(extendedAttributes, that.extendedAttributes) && Objects.equals(registryOwnerChange, that.registryOwnerChange) && Objects.equals(irtLockLiftedBy, that.irtLockLiftedBy) && Objects.equals(createdAt, that.createdAt) && Objects.equals(updatedAt, that.updatedAt);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, accountId, contactId, domainId, state, extendedAttributes, registryOwnerChange, irtLockLiftedBy, createdAt, updatedAt);
     }
 }

--- a/src/main/java/com/dnsimple/data/RegistrantChange.java
+++ b/src/main/java/com/dnsimple/data/RegistrantChange.java
@@ -1,0 +1,75 @@
+package com.dnsimple.data;
+
+import java.util.Map;
+
+public class RegistrantChange {
+    private final Long id;
+    private final Long type;
+    private final Long accountId;
+    private final Long contactId;
+    private final Long domainId;
+    private final String state;
+    private final Map<String, String> extendedAttributes;
+    private final Boolean registryOwnerChange;
+    private final String irtLockLiftedBy;
+    private final String createdAt;
+    private final String updatedAt;
+
+    public RegistrantChange(Long id, Long type, Long accountId, Long contactId, Long domainId, String state, Map<String, String> extendedAttributes, Boolean registryOwnerChange, String irtLockLiftedBy, String createdAt, String updatedAt) {
+        this.id = id;
+        this.type = type;
+        this.accountId = accountId;
+        this.contactId = contactId;
+        this.domainId = domainId;
+        this.state = state;
+        this.extendedAttributes = extendedAttributes;
+        this.registryOwnerChange = registryOwnerChange;
+        this.irtLockLiftedBy = irtLockLiftedBy;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Long getType() {
+        return type;
+    }
+
+    public Long getAccountId() {
+        return accountId;
+    }
+
+    public Long getContactId() {
+        return contactId;
+    }
+
+    public Long getDomainId() {
+        return domainId;
+    }
+
+    public String getState() {
+        return state;
+    }
+
+    public Map<String, String> getExtendedAttributes() {
+        return extendedAttributes;
+    }
+
+    public Boolean getRegistryOwnerChange() {
+        return registryOwnerChange;
+    }
+
+    public String getIrtLockLiftedBy() {
+        return irtLockLiftedBy;
+    }
+
+    public String getCreatedAt() {
+        return createdAt;
+    }
+
+    public String getUpdatedAt() {
+        return updatedAt;
+    }
+}

--- a/src/main/java/com/dnsimple/data/RegistrantChangeCheck.java
+++ b/src/main/java/com/dnsimple/data/RegistrantChangeCheck.java
@@ -1,0 +1,33 @@
+package com.dnsimple.data;
+
+import java.util.List;
+
+public class RegistrantChangeCheck {
+    private final Long contactId;
+    private final Long domainId;
+    private final List<TldExtendedAttribute> extendedAttributes;
+    private final Boolean registryOwnerChange;
+
+    public RegistrantChangeCheck(Long contactId, Long domainId, List<TldExtendedAttribute> extendedAttributes, Boolean registryOwnerChange) {
+        this.contactId = contactId;
+        this.domainId = domainId;
+        this.extendedAttributes = extendedAttributes;
+        this.registryOwnerChange = registryOwnerChange;
+    }
+
+    public Long getContactId() {
+        return contactId;
+    }
+
+    public Long getDomainId() {
+        return domainId;
+    }
+
+    public List<TldExtendedAttribute> getExtendedAttributes() {
+        return extendedAttributes;
+    }
+
+    public Boolean getRegistryOwnerChange() {
+        return registryOwnerChange;
+    }
+}

--- a/src/main/java/com/dnsimple/data/RegistrantChangeCheck.java
+++ b/src/main/java/com/dnsimple/data/RegistrantChangeCheck.java
@@ -1,6 +1,7 @@
 package com.dnsimple.data;
 
 import java.util.List;
+import java.util.Objects;
 
 public class RegistrantChangeCheck {
     private final Long contactId;
@@ -29,5 +30,18 @@ public class RegistrantChangeCheck {
 
     public Boolean getRegistryOwnerChange() {
         return registryOwnerChange;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        RegistrantChangeCheck that = (RegistrantChangeCheck) o;
+        return Objects.equals(contactId, that.contactId) && Objects.equals(domainId, that.domainId) && Objects.equals(extendedAttributes, that.extendedAttributes) && Objects.equals(registryOwnerChange, that.registryOwnerChange);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(contactId, domainId, extendedAttributes, registryOwnerChange);
     }
 }

--- a/src/main/java/com/dnsimple/endpoints/Registrar.java
+++ b/src/main/java/com/dnsimple/endpoints/Registrar.java
@@ -309,9 +309,7 @@ public class Registrar {
      * Start a registrant change.
      *
      * @param account The account ID
-     * @param domain  The domain name or ID
-     * @param contact The contact ID
-     * @param extendedAttributes Extended attributes
+     * @param input The input parameters
      * @return The registrant change response
      * @see <a href="https://developer.dnsimple.com/v2/registrar/#createRegistrantChange">https://developer.dnsimple.com/v2/registrar/#createRegistrantChange</a>
      */

--- a/src/main/java/com/dnsimple/endpoints/Registrar.java
+++ b/src/main/java/com/dnsimple/endpoints/Registrar.java
@@ -293,6 +293,17 @@ public class Registrar {
         return client.empty(DELETE, account + "/registrar/domains/" + domain + "/delegation/vanity", ListOptions.empty(), null);
     }
 
+    /**
+     * List registrant changes in the account.
+     *
+     * @param account The account ID
+     * @param options List options
+     * @return Registrant changes
+     * @see <a href="https://developer.dnsimple.com/v2/registrar/#listRegistrantChanges">https://developer.dnsimple.com/v2/registrar/#listRegistrantChanges</a>
+     */
+    public ListResponse<RegistrantChange> listRegistrantChanges(Number account, ListOptions options) {
+        return client.list(GET, account + "/registrar/registrant_changes", options, null, RegistrantChange.class);
+    }
 
     /**
      * Start a registrant change.
@@ -304,11 +315,43 @@ public class Registrar {
      * @return The registrant change response
      * @see <a href="https://developer.dnsimple.com/v2/registrar/#createRegistrantChange">https://developer.dnsimple.com/v2/registrar/#createRegistrantChange</a>
      */
-    public SimpleResponse<RegistrantChange> createRegistrantChange(Number account, String domain, String contact, Map<String, String> extendedAttributes) {
-        return client.simple(POST, account + "/registrar/registrant_changes", ListOptions.empty(), Map.of(
-                "domain_id", domain,
-                "contact_id", contact,
-                "extended_attributes", extendedAttributes
-        ), RegistrantChange.class);
+    public SimpleResponse<RegistrantChange> createRegistrantChange(Number account, CreateRegistrantChangeInput input) {
+        return client.simple(POST, account + "/registrar/registrant_changes", ListOptions.empty(), input, RegistrantChange.class);
+    }
+
+    /**
+     * Retrieves the requirements of a registrant change.
+     *
+     * @param account The account ID
+     * @param input The domain and contact to check
+     * @return The registrant change check response
+     * @see <a href="https://developer.dnsimple.com/v2/registrar/#checkRegistrantChange">https://developer.dnsimple.com/v2/registrar/#checkRegistrantChange</a>
+     */
+    public SimpleResponse<RegistrantChangeCheck> checkRegistrantChange(Number account, CheckRegistrantChangeInput input) {
+        return client.simple(POST, account + "/registrar/registrant_changes/check", ListOptions.empty(), input, RegistrantChangeCheck.class);
+    }
+
+    /**
+     * Retrieves the details of an existing registrant change.
+     *
+     * @param account The account ID
+     * @param registrantChange The registrant change
+     * @return The registrant change response
+     * @see <a href="https://developer.dnsimple.com/v2/registrar/#getRegistrantChange">https://developer.dnsimple.com/v2/registrar/#getRegistrantChange</a>
+     */
+    public SimpleResponse<RegistrantChange> getRegistrantChange(Number account, Number registrantChange) {
+        return client.simple(GET, account + "/registrar/registrant_changes/" + registrantChange, ListOptions.empty(), null, RegistrantChange.class);
+    }
+
+    /**
+     * Cancel an ongoing registrant change from the account.
+     *
+     * @param account The account ID
+     * @param registrantChange The registrant change
+     * @return The registrant change response
+     * @see <a href="https://developer.dnsimple.com/v2/registrar/#deleteRegistrantChange">https://developer.dnsimple.com/v2/registrar/#deleteRegistrantChange</a>
+     */
+    public EmptyResponse deleteRegistrantChange(Number account, Number registrantChange) {
+        return client.empty(DELETE, account + "/registrar/registrant_changes/" + registrantChange, ListOptions.empty(), null);
     }
 }

--- a/src/main/java/com/dnsimple/endpoints/Registrar.java
+++ b/src/main/java/com/dnsimple/endpoints/Registrar.java
@@ -7,7 +7,9 @@ import com.dnsimple.response.EmptyResponse;
 import com.dnsimple.response.ListResponse;
 import com.dnsimple.response.SimpleResponse;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static com.dnsimple.http.HttpMethod.*;
 
@@ -289,5 +291,24 @@ public class Registrar {
      */
     public EmptyResponse changeDomainDelegationFromVanity(Number account, String domain) {
         return client.empty(DELETE, account + "/registrar/domains/" + domain + "/delegation/vanity", ListOptions.empty(), null);
+    }
+
+
+    /**
+     * Start a registrant change.
+     *
+     * @param account The account ID
+     * @param domain  The domain name or ID
+     * @param contact The contact ID
+     * @param extendedAttributes Extended attributes
+     * @return The registrant change response
+     * @see <a href="https://developer.dnsimple.com/v2/registrar/#createRegistrantChange">https://developer.dnsimple.com/v2/registrar/#createRegistrantChange</a>
+     */
+    public SimpleResponse<RegistrantChange> createRegistrantChange(Number account, String domain, String contact, Map<String, String> extendedAttributes) {
+        return client.simple(POST, account + "/registrar/registrant_changes", ListOptions.empty(), Map.of(
+                "domain_id", domain,
+                "contact_id", contact,
+                "extended_attributes", extendedAttributes
+        ), RegistrantChange.class);
     }
 }

--- a/src/main/java/com/dnsimple/request/CheckRegistrantChangeInput.java
+++ b/src/main/java/com/dnsimple/request/CheckRegistrantChangeInput.java
@@ -1,0 +1,19 @@
+package com.dnsimple.request;
+
+public class CheckRegistrantChangeInput {
+    private final String domainId;
+    private final String contactId;
+
+    public CheckRegistrantChangeInput(String domainId, String contactId) {
+        this.domainId = domainId;
+        this.contactId = contactId;
+    }
+
+    public String getDomainId() {
+        return domainId;
+    }
+
+    public String getContactId() {
+        return contactId;
+    }
+}

--- a/src/main/java/com/dnsimple/request/CreateRegistrantChangeInput.java
+++ b/src/main/java/com/dnsimple/request/CreateRegistrantChangeInput.java
@@ -1,0 +1,27 @@
+package com.dnsimple.request;
+
+import java.util.Map;
+
+public class CreateRegistrantChangeInput {
+    private final String domainId;
+    private final String contactId;
+    private final Map<String, String> extendedAttributes;
+
+    public CreateRegistrantChangeInput(String domainId, String contactId, Map<String, String> extendedAttributes) {
+        this.domainId = domainId;
+        this.contactId = contactId;
+        this.extendedAttributes = extendedAttributes;
+    }
+
+    public String getDomainId() {
+        return domainId;
+    }
+
+    public String getContactId() {
+        return contactId;
+    }
+
+    public Map<String, String> getExtendedAttributes() {
+        return extendedAttributes;
+    }
+}

--- a/src/main/java/com/dnsimple/request/ListOptions.java
+++ b/src/main/java/com/dnsimple/request/ListOptions.java
@@ -1,12 +1,12 @@
 package com.dnsimple.request;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
+import java.net.URLEncoder;
+import java.util.*;
 
 import static com.dnsimple.request.PageRequest.MAX_ITEMS_PER_PAGE;
 import static com.dnsimple.request.SortField.Order.ASC;
 import static com.dnsimple.request.SortField.Order.DESC;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toList;
 
@@ -14,6 +14,7 @@ public class ListOptions {
     private final PageRequest pageRequest;
     private final List<Filter> filters;
     private final List<SortField> sortFields;
+    private final Map<String, String> otherOptions = new HashMap<>();
 
     private ListOptions(PageRequest pageRequest, List<Filter> filters, List<SortField> sortFields) {
         this.pageRequest = pageRequest;
@@ -53,6 +54,11 @@ public class ListOptions {
         return new ListOptions(pageRequest, filters, newSortFields);
     }
 
+    public ListOptions setOtherOption(String name, String value) {
+        this.otherOptions.put(name, value);
+        return this;
+    }
+
     public String asQueryString() {
         List<String> qsParams = new ArrayList<>();
         if (pageRequest != null)
@@ -60,6 +66,13 @@ public class ListOptions {
         qsParams.addAll(filters.stream().map(Filter::asQueryStringParam).collect(toList()));
         if (!sortFields.isEmpty())
             qsParams.add("sort=" + sortFields.stream().map(SortField::asQueryStringParam).collect(joining(",")));
+        for (var e : this.otherOptions.entrySet()) {
+            qsParams.add(String.format(
+                    "%s=%s",
+                    URLEncoder.encode(e.getKey(), UTF_8),
+                    URLEncoder.encode(e.getValue(), UTF_8)
+            ));
+        }
         return qsParams.isEmpty() ? "" : "?" + String.join("&", qsParams);
     }
 }

--- a/src/test/java/com/dnsimple/endpoints/RegistrarRegistrantChangeTest.java
+++ b/src/test/java/com/dnsimple/endpoints/RegistrarRegistrantChangeTest.java
@@ -1,0 +1,100 @@
+package com.dnsimple.endpoints;
+
+import com.dnsimple.data.RegistrantChange;
+import com.dnsimple.data.RegistrantChangeCheck;
+import com.dnsimple.request.CheckRegistrantChangeInput;
+import com.dnsimple.request.CreateRegistrantChangeInput;
+import com.dnsimple.request.ListOptions;
+import com.dnsimple.tools.DnsimpleTestBase;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+
+import static com.dnsimple.http.HttpMethod.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+public class RegistrarRegistrantChangeTest extends DnsimpleTestBase {
+    @Test
+    public void testListRegistrantChanges() {
+        server.stubFixtureAt("listRegistrantChanges/success.http");
+        var changes = client.registrar.listRegistrantChanges(101, ListOptions.empty()).getData();
+        assertThat(changes, hasSize(1));
+        var change = changes.get(0);
+        assertThat(change, is(new RegistrantChange(
+                101L,
+                101L,
+                101L,
+                101L,
+                "new",
+                new HashMap<>(),
+                true,
+                null,
+                "2017-02-03T17:43:22Z",
+                "2017-02-03T17:43:22Z"
+        )));
+    }
+
+    @Test
+    public void testCreateRegistrantChange() {
+        server.stubFixtureAt("createRegistrantChange/success.http");
+        var change = client.registrar.createRegistrantChange(101, new CreateRegistrantChangeInput(
+                "101",
+                "101",
+                new HashMap<>()
+        )).getData();
+        assertThat(change, is(new RegistrantChange(
+                101L,
+                101L,
+                101L,
+                101L,
+                "new",
+                new HashMap<>(),
+                true,
+                null,
+                "2017-02-03T17:43:22Z",
+                "2017-02-03T17:43:22Z"
+        )));
+    }
+
+    @Test
+    public void testCheckRegistrantChange() {
+        server.stubFixtureAt("checkRegistrantChange/success.http");
+        var change = client.registrar.checkRegistrantChange(101, new CheckRegistrantChangeInput(
+                "101",
+                "101"
+        )).getData();
+        assertThat(change, is(new RegistrantChangeCheck(
+                101L,
+                101L,
+                new ArrayList<>(),
+                true
+        )));
+    }
+
+    @Test
+    public void testGetRegistrantChange() {
+        server.stubFixtureAt("getRegistrantChange/success.http");
+        var change = client.registrar.getRegistrantChange(101, 101).getData();
+        assertThat(change, is(new RegistrantChange(
+                101L,
+                101L,
+                101L,
+                101L,
+                "new",
+                new HashMap<>(),
+                true,
+                null,
+                "2017-02-03T17:43:22Z",
+                "2017-02-03T17:43:22Z"
+        )));
+    }
+
+    @Test
+    public void testDeleteRegistrantChange() {
+        server.stubFixtureAt("deleteRegistrantChange/success.http");
+        client.registrar.deleteRegistrantChange(101, 101);
+        assertThat(server.getRecordedRequest().getMethod(), is(DELETE));
+    }
+}

--- a/src/test/resources/com/dnsimple/checkRegistrantChange/error-contactnotfound.http
+++ b/src/test/resources/com/dnsimple/checkRegistrantChange/error-contactnotfound.http
@@ -1,0 +1,14 @@
+HTTP/1.1 404
+server: nginx
+date: Tue, 22 Aug 2023 13:59:02 GMT
+content-type: application/json; charset=utf-8
+x-ratelimit-limit: 2400
+x-ratelimit-remaining: 2398
+x-ratelimit-reset: 1692716201
+x-work-with-us: Love automation? So do we! https://dnsimple.com/jobs
+cache-control: no-cache
+x-request-id: b1dd3f42-ebb9-42fd-a121-d595de96f667
+x-runtime: 0.019122
+strict-transport-security: max-age=63072000
+
+{"message":"Contact `21` not found"}

--- a/src/test/resources/com/dnsimple/checkRegistrantChange/error-domainnotfound.http
+++ b/src/test/resources/com/dnsimple/checkRegistrantChange/error-domainnotfound.http
@@ -1,0 +1,15 @@
+HTTP/1.1 404 
+server: nginx
+date: Tue, 22 Aug 2023 11:09:40 GMT
+content-type: application/json; charset=utf-8
+x-ratelimit-limit: 2400
+x-ratelimit-remaining: 2395
+x-ratelimit-reset: 1692705338
+x-work-with-us: Love automation? So do we! https://dnsimple.com/jobs
+etag: W/"cef1e7d85d0b9bfd25e81b812891d34f"
+cache-control: max-age=0, private, must-revalidate
+x-request-id: 5b0d8bfb-7b6a-40b5-a079-b640fd817e34
+x-runtime: 3.066249
+strict-transport-security: max-age=63072000
+
+{"message":"Domain `dnsimple-rraform.bio` not found"}

--- a/src/test/resources/com/dnsimple/checkRegistrantChange/success.http
+++ b/src/test/resources/com/dnsimple/checkRegistrantChange/success.http
@@ -1,0 +1,15 @@
+HTTP/1.1 200
+server: nginx
+date: Tue, 22 Aug 2023 11:09:40 GMT
+content-type: application/json; charset=utf-8
+x-ratelimit-limit: 2400
+x-ratelimit-remaining: 2395
+x-ratelimit-reset: 1692705338
+x-work-with-us: Love automation? So do we! https://dnsimple.com/jobs
+etag: W/"cef1e7d85d0b9bfd25e81b812891d34f"
+cache-control: max-age=0, private, must-revalidate
+x-request-id: 5b0d8bfb-7b6a-40b5-a079-b640fd817e34
+x-runtime: 3.066249
+strict-transport-security: max-age=63072000
+
+{"data":{"domain_id":101,"contact_id":101,"extended_attributes":[],"registry_owner_change":true}}

--- a/src/test/resources/com/dnsimple/createRegistrantChange/success.http
+++ b/src/test/resources/com/dnsimple/createRegistrantChange/success.http
@@ -1,0 +1,14 @@
+HTTP/1.1 202
+server: nginx
+date: Tue, 22 Aug 2023 11:11:00 GMT
+content-type: application/json; charset=utf-8
+x-ratelimit-limit: 2400
+x-ratelimit-remaining: 2394
+x-ratelimit-reset: 1692705339
+x-work-with-us: Love automation? So do we! https://dnsimple.com/jobs
+cache-control: no-cache
+x-request-id: 26bf7ff9-2075-42b0-9431-1778c825b6b0
+x-runtime: 3.408950
+strict-transport-security: max-age=63072000
+
+{"data":{"id":101,"account_id":101,"domain_id":101,"contact_id":101,"state":"new","extended_attributes":{},"registry_owner_change":true,"irt_lock_lifted_by":null,"created_at":"2017-02-03T17:43:22Z","updated_at":"2017-02-03T17:43:22Z"}}

--- a/src/test/resources/com/dnsimple/deleteRegistrantChange/success.http
+++ b/src/test/resources/com/dnsimple/deleteRegistrantChange/success.http
@@ -1,0 +1,12 @@
+HTTP/1.1 201
+server: nginx
+date: Tue, 22 Aug 2023 11:14:44 GMT
+content-type: application/json; charset=utf-8
+x-ratelimit-limit: 2400
+x-ratelimit-remaining: 2391
+x-ratelimit-reset: 1692705338
+x-work-with-us: Love automation? So do we! https://dnsimple.com/jobs
+cache-control: no-cache
+x-request-id: b123e1f0-aa70-4abb-95cf-34f377c83ef4
+x-runtime: 0.114839
+strict-transport-security: max-age=63072000

--- a/src/test/resources/com/dnsimple/deleteRegistrantChange/success.http
+++ b/src/test/resources/com/dnsimple/deleteRegistrantChange/success.http
@@ -1,7 +1,6 @@
-HTTP/1.1 201
+HTTP/1.1 204
 server: nginx
 date: Tue, 22 Aug 2023 11:14:44 GMT
-content-type: application/json; charset=utf-8
 x-ratelimit-limit: 2400
 x-ratelimit-remaining: 2391
 x-ratelimit-reset: 1692705338
@@ -10,3 +9,4 @@ cache-control: no-cache
 x-request-id: b123e1f0-aa70-4abb-95cf-34f377c83ef4
 x-runtime: 0.114839
 strict-transport-security: max-age=63072000
+

--- a/src/test/resources/com/dnsimple/getRegistrantChange/success.http
+++ b/src/test/resources/com/dnsimple/getRegistrantChange/success.http
@@ -1,0 +1,15 @@
+HTTP/1.1 200
+server: nginx
+date: Tue, 22 Aug 2023 11:13:58 GMT
+content-type: application/json; charset=utf-8
+x-ratelimit-limit: 2400
+x-ratelimit-remaining: 2392
+x-ratelimit-reset: 1692705338
+x-work-with-us: Love automation? So do we! https://dnsimple.com/jobs
+etag: W/"76c5d4c7579b754b94a42ac7fa37a901"
+cache-control: max-age=0, private, must-revalidate
+x-request-id: e910cd08-3f9c-4da4-9986-50dbe9c3bc55
+x-runtime: 0.022006
+strict-transport-security: max-age=63072000
+
+{"data":{"id":101,"account_id":101,"domain_id":101,"contact_id":101,"state":"new","extended_attributes":{},"registry_owner_change":true,"irt_lock_lifted_by":null,"created_at":"2017-02-03T17:43:22Z","updated_at":"2017-02-03T17:43:22Z"}}

--- a/src/test/resources/com/dnsimple/listRegistrantChanges/success.http
+++ b/src/test/resources/com/dnsimple/listRegistrantChanges/success.http
@@ -1,0 +1,15 @@
+HTTP/1.1 200
+server: nginx
+date: Tue, 22 Aug 2023 11:12:49 GMT
+content-type: application/json; charset=utf-8
+x-ratelimit-limit: 2400
+x-ratelimit-remaining: 2393
+x-ratelimit-reset: 1692705338
+x-work-with-us: Love automation? So do we! https://dnsimple.com/jobs
+etag: W/"0049703ea058b06346df4c0e169eac29"
+cache-control: max-age=0, private, must-revalidate
+x-request-id: fd0334ce-414a-4872-8889-e548e0b1410c
+x-runtime: 0.030759
+strict-transport-security: max-age=63072000
+
+{"data":[{"id":101,"account_id":101,"domain_id":101,"contact_id":101,"state":"new","extended_attributes":{},"registry_owner_change":true,"irt_lock_lifted_by":null,"created_at":"2017-02-03T17:43:22Z","updated_at":"2017-02-03T17:43:22Z"}],"pagination":{"current_page":1,"per_page":30,"total_entries":1,"total_pages":1}}


### PR DESCRIPTION
This PR introduces 5 new endpoints that are part of the domain contact management API that was introduced in https://github.com/dnsimple/dnsimple-developer/pull/501.

The following endpoints have been added:
- **listRegistrantChanges**: GET `/{account}/registrar/registrant_changes`
- **createRegistrantChange**: POST `/{account}/registrar/registrant_changes`
- **checkRegistrantChange**: POST `/{account}/registrar/registrant_changes/check`
- **getRegistrantChange**: GET `/{account}/registrar/registrant_changes/{registrantchange}`
- **deleteRegistrantChange**: DELETE `/{account}/registrar/registrant_changes/{registrantchange}`

Belongs to https://github.com/dnsimple/dnsimple-business/issues/1729