### PR TITLE
Add support for domain transfer lock APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 FEATURES:
 
 - NEW: Added `listRegistrantChanges`, `createRegistrantChange`, `checkRegistrantChange`, `getRegistrantChange`, and `deleteRegistrantChange` methods to `Registrar` to manage registrant changes. (dnsimple/dnsimple-java#159)
+- NEW: Added `getDomainTransferLock`, `enableDomainTransferLock`, and `disableDomainTransferLock` methods to `Registrar` to manage domain transfer locks. (dnsimple/dnsimple-java#161)
 
 ## 0.11.0
 

--- a/src/main/java/com/dnsimple/data/DomainTransferLock.java
+++ b/src/main/java/com/dnsimple/data/DomainTransferLock.java
@@ -1,0 +1,28 @@
+package com.dnsimple.data;
+
+import java.util.Objects;
+
+public class DomainTransferLock {
+    private final Boolean enabled;
+
+    public DomainTransferLock(Boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public Boolean getEnabled() {
+        return enabled;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        DomainTransferLock that = (DomainTransferLock) o;
+        return Objects.equals(enabled, that.enabled);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(enabled);
+    }
+}

--- a/src/main/java/com/dnsimple/endpoints/Registrar.java
+++ b/src/main/java/com/dnsimple/endpoints/Registrar.java
@@ -352,4 +352,40 @@ public class Registrar {
     public EmptyResponse deleteRegistrantChange(Number account, Number registrantChange) {
         return client.empty(DELETE, account + "/registrar/registrant_changes/" + registrantChange, ListOptions.empty(), null);
     }
+
+    /**
+     * Gets the transfer lock status for a domain.
+     *
+     * @param account The account ID
+     * @param domain The domain name or ID
+     * @return The transfer lock status
+     * @see <a href="https://developer.dnsimple.com/v2/registrar/#getDomainTransferLock">https://developer.dnsimple.com/v2/registrar/#getDomainTransferLock</a>
+     */
+    public SimpleResponse<DomainTransferLock> getDomainTransferLock(Number account, String domain) {
+        return client.simple(GET, account + "/registrar/domains/" + domain + "/transfer_lock", ListOptions.empty(), null, DomainTransferLock.class);
+    }
+
+    /**
+     * Locks the domain to prevent unauthorized transfers.
+     *
+     * @param account The account ID
+     * @param domain The domain name or ID
+     * @return The transfer lock status
+     * @see <a href="https://developer.dnsimple.com/v2/registrar/#enableDomainTransferLock">https://developer.dnsimple.com/v2/registrar/#enableDomainTransferLock</a>
+     */
+    public SimpleResponse<DomainTransferLock> enableDomainTransferLock(Number account, String domain) {
+        return client.simple(POST, account + "/registrar/domains/" + domain + "/transfer_lock", ListOptions.empty(), null, DomainTransferLock.class);
+    }
+
+    /**
+     * Unlocks the domain to allow domain transfers.
+     *
+     * @param account The account ID
+     * @param domain The domain name or ID
+     * @return The transfer lock status
+     * @see <a href="https://developer.dnsimple.com/v2/registrar/#disableDomainTransferLock">https://developer.dnsimple.com/v2/registrar/#disableDomainTransferLock</a>
+     */
+    public SimpleResponse<DomainTransferLock> disableDomainTransferLock(Number account, String domain) {
+        return client.simple(DELETE, account + "/registrar/domains/" + domain + "/transfer_lock", ListOptions.empty(), null, DomainTransferLock.class);
+    }
 }

--- a/src/test/java/com/dnsimple/endpoints/RegistrarDomainTransferLockTest.java
+++ b/src/test/java/com/dnsimple/endpoints/RegistrarDomainTransferLockTest.java
@@ -1,0 +1,46 @@
+package com.dnsimple.endpoints;
+
+import com.dnsimple.data.DomainTransferLock;
+import com.dnsimple.data.VanityNameServer;
+import com.dnsimple.tools.DnsimpleTestBase;
+import org.junit.Test;
+
+import java.time.OffsetDateTime;
+import java.util.Arrays;
+import java.util.List;
+
+import static com.dnsimple.http.HttpMethod.*;
+import static java.time.ZoneOffset.UTC;
+import static java.util.Collections.singletonList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+
+public class RegistrarDomainTransferLockTest extends DnsimpleTestBase {
+    @Test
+    public void testGetDomainDelegation() {
+        server.stubFixtureAt("getDomainTransferLock/success.http");
+        DomainTransferLock l = client.registrar.getDomainTransferLock(1010, "example.com").getData();
+        assertThat(server.getRecordedRequest().getMethod(), is(GET));
+        assertThat(server.getRecordedRequest().getPath(), is("/v2/1010/registrar/domains/example.com/transfer_lock"));
+        assertThat(l, is(new DomainTransferLock(true)));
+    }
+
+    @Test
+    public void testEnableDomainDelegation() {
+        server.stubFixtureAt("enableDomainTransferLock/success.http");
+        DomainTransferLock l = client.registrar.enableDomainTransferLock(1010, "example.com").getData();
+        assertThat(server.getRecordedRequest().getMethod(), is(POST));
+        assertThat(server.getRecordedRequest().getPath(), is("/v2/1010/registrar/domains/example.com/transfer_lock"));
+        assertThat(l, is(new DomainTransferLock(true)));
+    }
+
+    @Test
+    public void testDisableDomainDelegation() {
+        server.stubFixtureAt("disableDomainTransferLock/success.http");
+        DomainTransferLock l = client.registrar.disableDomainTransferLock(1010, "example.com").getData();
+        assertThat(server.getRecordedRequest().getMethod(), is(DELETE));
+        assertThat(server.getRecordedRequest().getPath(), is("/v2/1010/registrar/domains/example.com/transfer_lock"));
+        assertThat(l, is(new DomainTransferLock(false)));
+    }
+}

--- a/src/test/resources/com/dnsimple/disableDomainTransferLock/success.http
+++ b/src/test/resources/com/dnsimple/disableDomainTransferLock/success.http
@@ -1,0 +1,20 @@
+HTTP/1.1 200 OK
+Server: nginx
+Date: Tue, 15 Aug 2023 09:58:37 GMT
+Content-Type: application/json; charset=utf-8
+Connection: keep-alive
+X-RateLimit-Limit: 2400
+X-RateLimit-Remaining: 2398
+X-RateLimit-Reset: 1488538623
+ETag: W/"fc2368a31a1b6a3afcca33bb37ff6b9d"
+Cache-Control: max-age=0, private, must-revalidate
+X-Request-Id: 8b0fe49a-c810-4552-84ab-a1cd9b4a7786
+X-Runtime: 0.024780
+X-Content-Type-Options: nosniff
+X-Download-Options: noopen
+X-Frame-Options: DENY
+X-Permitted-Cross-Domain-Policies: none
+X-XSS-Protection: 1; mode=block
+Strict-Transport-Security: max-age=31536000
+
+{"data":{"enabled":false}}

--- a/src/test/resources/com/dnsimple/enableDomainTransferLock/success.http
+++ b/src/test/resources/com/dnsimple/enableDomainTransferLock/success.http
@@ -1,0 +1,20 @@
+HTTP/1.1 201 Created
+Server: nginx
+Date: Tue, 15 Aug 2023 09:58:37 GMT
+Content-Type: application/json; charset=utf-8
+Connection: keep-alive
+X-RateLimit-Limit: 2400
+X-RateLimit-Remaining: 2398
+X-RateLimit-Reset: 1488538623
+ETag: W/"fc2368a31a1b6a3afcca33bb37ff6b9d"
+Cache-Control: max-age=0, private, must-revalidate
+X-Request-Id: 8b0fe49a-c810-4552-84ab-a1cd9b4a7786
+X-Runtime: 0.024780
+X-Content-Type-Options: nosniff
+X-Download-Options: noopen
+X-Frame-Options: DENY
+X-Permitted-Cross-Domain-Policies: none
+X-XSS-Protection: 1; mode=block
+Strict-Transport-Security: max-age=31536000
+
+{"data":{"enabled":true}}

--- a/src/test/resources/com/dnsimple/getDomainTransferLock/success.http
+++ b/src/test/resources/com/dnsimple/getDomainTransferLock/success.http
@@ -1,0 +1,20 @@
+HTTP/1.1 200 OK
+Server: nginx
+Date: Tue, 15 Aug 2023 09:58:37 GMT
+Content-Type: application/json; charset=utf-8
+Connection: keep-alive
+X-RateLimit-Limit: 2400
+X-RateLimit-Remaining: 2398
+X-RateLimit-Reset: 1488538623
+ETag: W/"fc2368a31a1b6a3afcca33bb37ff6b9d"
+Cache-Control: max-age=0, private, must-revalidate
+X-Request-Id: 8b0fe49a-c810-4552-84ab-a1cd9b4a7786
+X-Runtime: 0.024780
+X-Content-Type-Options: nosniff
+X-Download-Options: noopen
+X-Frame-Options: DENY
+X-Permitted-Cross-Domain-Policies: none
+X-XSS-Protection: 1; mode=block
+Strict-Transport-Security: max-age=31536000
+
+{"data":{"enabled":true}}


### PR DESCRIPTION
This PR adds support for domain transfer lock APIs.

Belongs to https://github.com/dnsimple/dnsimple-business/issues/1728.