### PR TITLE
Add missing attributes to the Zone API responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 ## main
 
+ENHANCEMENTS:
+
+- NEW: Added `Secondary`, `LastTransferredAt`, `Active` to `Zone` (dnsimple/dnsimple-java)
+
 ## 0.13.0
+
+FEATURES:
 
 - NEW: Added `listCharges` method to `Billing` to manage account billing charges. (dnsimple/dnsimple-java#163)
 

--- a/src/main/java/com/dnsimple/data/Zone.java
+++ b/src/main/java/com/dnsimple/data/Zone.java
@@ -7,14 +7,20 @@ public class Zone {
     private final Long accountId;
     private final String name;
     private final Boolean reverse;
+    private final Boolean secondary;
+    private final OffsetDateTime last_transferred_at;
+    private final Boolean active;
     private final OffsetDateTime createdAt;
     private final OffsetDateTime updatedAt;
 
-    public Zone(Long id, Long accountId, String name, Boolean reverse, OffsetDateTime createdAt, OffsetDateTime updatedAt) {
+    public Zone(Long id, Long accountId, String name, Boolean reverse, Boolean secondary, OffsetDateTime last_transferred_at, Boolean active, OffsetDateTime createdAt, OffsetDateTime updatedAt) {
         this.id = id;
         this.accountId = accountId;
         this.name = name;
         this.reverse = reverse;
+        this.secondary = secondary;
+        this.last_transferred_at = last_transferred_at;
+        this.active = active;
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;
     }
@@ -33,6 +39,18 @@ public class Zone {
 
     public Boolean isReverse() {
         return reverse;
+    }
+
+    public Boolean isSecondary() {
+        return secondary;
+    }
+
+    public OffsetDateTime getLastTransferredAt() {
+        return last_transferred_at;
+    }
+
+    public Boolean isActive() {
+        return active;
     }
 
     public OffsetDateTime getCreatedAt() {

--- a/src/main/java/com/dnsimple/data/Zone.java
+++ b/src/main/java/com/dnsimple/data/Zone.java
@@ -8,18 +8,18 @@ public class Zone {
     private final String name;
     private final Boolean reverse;
     private final Boolean secondary;
-    private final OffsetDateTime last_transferred_at;
+    private final OffsetDateTime lastTransferredAt;
     private final Boolean active;
     private final OffsetDateTime createdAt;
     private final OffsetDateTime updatedAt;
 
-    public Zone(Long id, Long accountId, String name, Boolean reverse, Boolean secondary, OffsetDateTime last_transferred_at, Boolean active, OffsetDateTime createdAt, OffsetDateTime updatedAt) {
+    public Zone(Long id, Long accountId, String name, Boolean reverse, Boolean secondary, OffsetDateTime lastTransferredAt, Boolean active, OffsetDateTime createdAt, OffsetDateTime updatedAt) {
         this.id = id;
         this.accountId = accountId;
         this.name = name;
         this.reverse = reverse;
         this.secondary = secondary;
-        this.last_transferred_at = last_transferred_at;
+        this.lastTransferredAt = lastTransferredAt;
         this.active = active;
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;
@@ -46,7 +46,7 @@ public class Zone {
     }
 
     public OffsetDateTime getLastTransferredAt() {
-        return last_transferred_at;
+        return lastTransferredAt;
     }
 
     public Boolean isActive() {

--- a/src/test/java/com/dnsimple/endpoints/ZonesTest.java
+++ b/src/test/java/com/dnsimple/endpoints/ZonesTest.java
@@ -98,7 +98,7 @@ public class ZonesTest extends DnsimpleTestBase {
         assertThat(zone.getName(), is("example-alpha.com"));
         assertThat(zone.isReverse(), is(false));
         assertThat(zone.isSecondary(), is(false));
-        assertNull(zone.getLastTransferredAt());
+        assertThat(zone.getLastTransferredAt(), is(nullValue()));
         assertThat(zone.isActive(), is(true));
         assertThat(zone.getCreatedAt(), is(OffsetDateTime.of(2015, 4, 23, 7, 40, 3, 0, ZoneOffset.UTC)));
         assertThat(zone.getUpdatedAt(), is(OffsetDateTime.of(2015, 4, 23, 7, 40, 3, 0, ZoneOffset.UTC)));

--- a/src/test/java/com/dnsimple/endpoints/ZonesTest.java
+++ b/src/test/java/com/dnsimple/endpoints/ZonesTest.java
@@ -106,7 +106,8 @@ public class ZonesTest extends DnsimpleTestBase {
     @Test
     public void testGetZoneWhenZoneNotFound() {
         server.stubFixtureAt("notfound-zone.http");
-        assertThat(() -> client.zones.getZone(1, "example.com"), thrownException(is(instanceOf(ResourceNotFoundException.class))));
+        assertThat(() -> client.zones.getZone(1, "example.com"),
+                thrownException(is(instanceOf(ResourceNotFoundException.class))));
     }
 
     @Test
@@ -127,7 +128,8 @@ public class ZonesTest extends DnsimpleTestBase {
     @Test
     public void testGetZoneFileWhenZoneNotFound() {
         server.stubFixtureAt("notfound-zone.http");
-        assertThat(() -> client.zones.getZoneFile(1, "example.com"), thrownException(is(instanceOf(ResourceNotFoundException.class))));
+        assertThat(() -> client.zones.getZoneFile(1, "example.com"),
+                thrownException(is(instanceOf(ResourceNotFoundException.class))));
     }
 
     @Test
@@ -147,13 +149,15 @@ public class ZonesTest extends DnsimpleTestBase {
     @Test
     public void testCheckZoneDistributionFailedCheck() {
         server.stubFixtureAt("checkZoneDistribution/error.http");
-        assertThat(() -> client.zones.checkZoneDistribution(1, "example.com"), thrownException(is(instanceOf(DnsimpleException.class))));
+        assertThat(() -> client.zones.checkZoneDistribution(1, "example.com"),
+                thrownException(is(instanceOf(DnsimpleException.class))));
     }
 
     @Test
     public void testCheckZoneDistributionWhenZoneNotFound() {
         server.stubFixtureAt("notfound-zone.http");
-        assertThat(() -> client.zones.checkZoneDistribution(1, "example.com"), thrownException(is(instanceOf(ResourceNotFoundException.class))));
+        assertThat(() -> client.zones.checkZoneDistribution(1, "example.com"),
+                thrownException(is(instanceOf(ResourceNotFoundException.class))));
     }
 
     @Test
@@ -173,18 +177,21 @@ public class ZonesTest extends DnsimpleTestBase {
     @Test
     public void testCheckZoneRecordDistributionFailedCheck() {
         server.stubFixtureAt("checkZoneRecordDistribution/error.http");
-        assertThat(() -> client.zones.checkZoneRecordDistribution(1010, "example.com", 1010), thrownException(is(instanceOf(DnsimpleException.class))));
+        assertThat(() -> client.zones.checkZoneRecordDistribution(1010, "example.com", 1010),
+                thrownException(is(instanceOf(DnsimpleException.class))));
     }
 
     @Test
     public void testCheckZoneRecordDistributionWhenZoneNotFound() {
         server.stubFixtureAt("notfound-zone.http");
-        assertThat(() -> client.zones.checkZoneRecordDistribution(1010, "example.com", 1010), thrownException(is(instanceOf(ResourceNotFoundException.class))));
+        assertThat(() -> client.zones.checkZoneRecordDistribution(1010, "example.com", 1010),
+                thrownException(is(instanceOf(ResourceNotFoundException.class))));
     }
 
     @Test
     public void testCheckZoneRecordDistributionWhenZoneRecordNotFound() {
         server.stubFixtureAt("notfound-record.http");
-        assertThat(() -> client.zones.checkZoneRecordDistribution(1010, "example.com", 1010), thrownException(is(instanceOf(ResourceNotFoundException.class))));
+        assertThat(() -> client.zones.checkZoneRecordDistribution(1010, "example.com", 1010),
+                thrownException(is(instanceOf(ResourceNotFoundException.class))));
     }
 }

--- a/src/test/java/com/dnsimple/endpoints/ZonesTest.java
+++ b/src/test/java/com/dnsimple/endpoints/ZonesTest.java
@@ -19,7 +19,6 @@ import static com.dnsimple.http.HttpMethod.GET;
 import static com.dnsimple.tools.CustomMatchers.thrownException;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertNull;
 
 public class ZonesTest extends DnsimpleTestBase {
     @Test
@@ -107,8 +106,7 @@ public class ZonesTest extends DnsimpleTestBase {
     @Test
     public void testGetZoneWhenZoneNotFound() {
         server.stubFixtureAt("notfound-zone.http");
-        assertThat(() -> client.zones.getZone(1, "example.com"),
-                thrownException(is(instanceOf(ResourceNotFoundException.class))));
+        assertThat(() -> client.zones.getZone(1, "example.com"), thrownException(is(instanceOf(ResourceNotFoundException.class))));
     }
 
     @Test
@@ -129,8 +127,7 @@ public class ZonesTest extends DnsimpleTestBase {
     @Test
     public void testGetZoneFileWhenZoneNotFound() {
         server.stubFixtureAt("notfound-zone.http");
-        assertThat(() -> client.zones.getZoneFile(1, "example.com"),
-                thrownException(is(instanceOf(ResourceNotFoundException.class))));
+        assertThat(() -> client.zones.getZoneFile(1, "example.com"), thrownException(is(instanceOf(ResourceNotFoundException.class))));
     }
 
     @Test
@@ -150,15 +147,13 @@ public class ZonesTest extends DnsimpleTestBase {
     @Test
     public void testCheckZoneDistributionFailedCheck() {
         server.stubFixtureAt("checkZoneDistribution/error.http");
-        assertThat(() -> client.zones.checkZoneDistribution(1, "example.com"),
-                thrownException(is(instanceOf(DnsimpleException.class))));
+        assertThat(() -> client.zones.checkZoneDistribution(1, "example.com"), thrownException(is(instanceOf(DnsimpleException.class))));
     }
 
     @Test
     public void testCheckZoneDistributionWhenZoneNotFound() {
         server.stubFixtureAt("notfound-zone.http");
-        assertThat(() -> client.zones.checkZoneDistribution(1, "example.com"),
-                thrownException(is(instanceOf(ResourceNotFoundException.class))));
+        assertThat(() -> client.zones.checkZoneDistribution(1, "example.com"), thrownException(is(instanceOf(ResourceNotFoundException.class))));
     }
 
     @Test
@@ -178,21 +173,18 @@ public class ZonesTest extends DnsimpleTestBase {
     @Test
     public void testCheckZoneRecordDistributionFailedCheck() {
         server.stubFixtureAt("checkZoneRecordDistribution/error.http");
-        assertThat(() -> client.zones.checkZoneRecordDistribution(1010, "example.com", 1010),
-                thrownException(is(instanceOf(DnsimpleException.class))));
+        assertThat(() -> client.zones.checkZoneRecordDistribution(1010, "example.com", 1010), thrownException(is(instanceOf(DnsimpleException.class))));
     }
 
     @Test
     public void testCheckZoneRecordDistributionWhenZoneNotFound() {
         server.stubFixtureAt("notfound-zone.http");
-        assertThat(() -> client.zones.checkZoneRecordDistribution(1010, "example.com", 1010),
-                thrownException(is(instanceOf(ResourceNotFoundException.class))));
+        assertThat(() -> client.zones.checkZoneRecordDistribution(1010, "example.com", 1010), thrownException(is(instanceOf(ResourceNotFoundException.class))));
     }
 
     @Test
     public void testCheckZoneRecordDistributionWhenZoneRecordNotFound() {
         server.stubFixtureAt("notfound-record.http");
-        assertThat(() -> client.zones.checkZoneRecordDistribution(1010, "example.com", 1010),
-                thrownException(is(instanceOf(ResourceNotFoundException.class))));
+        assertThat(() -> client.zones.checkZoneRecordDistribution(1010, "example.com", 1010), thrownException(is(instanceOf(ResourceNotFoundException.class))));
     }
 }

--- a/src/test/java/com/dnsimple/endpoints/ZonesTest.java
+++ b/src/test/java/com/dnsimple/endpoints/ZonesTest.java
@@ -19,6 +19,7 @@ import static com.dnsimple.http.HttpMethod.GET;
 import static com.dnsimple.tools.CustomMatchers.thrownException;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.assertNull;
 
 public class ZonesTest extends DnsimpleTestBase {
     @Test
@@ -96,6 +97,9 @@ public class ZonesTest extends DnsimpleTestBase {
         assertThat(zone.getAccountId(), is(1010L));
         assertThat(zone.getName(), is("example-alpha.com"));
         assertThat(zone.isReverse(), is(false));
+        assertThat(zone.isSecondary(), is(false));
+        assertNull(zone.getLastTransferredAt());
+        assertThat(zone.isActive(), is(true));
         assertThat(zone.getCreatedAt(), is(OffsetDateTime.of(2015, 4, 23, 7, 40, 3, 0, ZoneOffset.UTC)));
         assertThat(zone.getUpdatedAt(), is(OffsetDateTime.of(2015, 4, 23, 7, 40, 3, 0, ZoneOffset.UTC)));
     }

--- a/src/test/resources/com/dnsimple/getZone/success.http
+++ b/src/test/resources/com/dnsimple/getZone/success.http
@@ -13,4 +13,4 @@ X-Request-Id: 93182033-a215-484e-a107-5235fa48001c
 X-Runtime: 0.177942
 Strict-Transport-Security: max-age=31536000
 
-{"data":{"id":1,"account_id":1010,"name":"example-alpha.com","reverse":false,"created_at":"2015-04-23T07:40:03Z","updated_at":"2015-04-23T07:40:03Z"}}
+{"data":{"id":1,"account_id":1010,"name":"example-alpha.com","reverse":false,"secondary":false,"last_transferred_at":null,"active":true,"created_at":"2015-04-23T07:40:03Z","updated_at":"2015-04-23T07:40:03Z"}}

--- a/src/test/resources/com/dnsimple/listZones/success.http
+++ b/src/test/resources/com/dnsimple/listZones/success.http
@@ -13,4 +13,4 @@ X-Request-Id: 01be9fa5-3a00-4d51-a927-f17587cb67ec
 X-Runtime: 0.037083
 Strict-Transport-Security: max-age=31536000
 
-{"data":[{"id":1,"account_id":1010,"name":"example-alpha.com","reverse":false,"created_at":"2015-04-23T07:40:03Z","updated_at":"2015-04-23T07:40:03Z"},{"id":2,"account_id":1010,"name":"example-beta.com","reverse":true,"created_at":"2015-04-23T07:40:03Z","updated_at":"2015-04-23T07:40:03Z"}],"pagination":{"current_page":1,"per_page":30,"total_entries":2,"total_pages":1}}
+{"data":[{"id":1,"account_id":1010,"name":"example-alpha.com","reverse":false,"secondary":false,"last_transferred_at":null,"active":true,"created_at":"2015-04-23T07:40:03Z","updated_at":"2015-04-23T07:40:03Z"},{"id":2,"account_id":1010,"name":"example-beta.com","reverse":false,"secondary":false,"last_transferred_at":null,"active":true,"created_at":"2015-04-23T07:40:03Z","updated_at":"2015-04-23T07:40:03Z"}],"pagination":{"current_page":1,"per_page":30,"total_entries":2,"total_pages":1}}


### PR DESCRIPTION
This PR adds [missing attributes](https://github.com/dnsimple/dnsimple-developer/pull/542) of the Zone response:

- `Secondary`, `LastTransferredAt`, `Active` to `Zone` struct

Belongs to https://github.com/dnsimple/dnsimple-external-integrations/issues/17