### PR TITLE
Patch cycle - 2024 / Cycle 5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
         java-version:
           - '17'
           - '21'
+          - '23'
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK ${{ matrix.java-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,6 @@ jobs:
     strategy:
       matrix:
         java-version:
-          - '17'
           - '21'
           - '23'
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ build
 .gradle
 gradle.properties
 .DS_Store
+.tool-versions

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,0 @@
-java temurin-21.0.2+13.0.LTS

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - CHANGED: Deprecated `from` and `to` fields in `EmailForward`
 - CHANGE: Drop support for Java JDK 17
 - CHANGE: Add support for Java JDK 23
+- CHANGE: `DomainCollaborators` have been deprecated and will be removed in the next major version. Please use our Domain Access Control feature.
 
 ## 1.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - NEW: Added `alias_email` and `destination_email` to `EmailForward`
 - CHANGED: Deprecated `from` and `to` fields in `EmailForward`
+- CHANGE: Add support for Java JDK 23
 
 ## 1.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - NEW: Added `alias_email` and `destination_email` to `EmailForward`
 - CHANGED: Deprecated `from` and `to` fields in `EmailForward`
+- CHANGE: Drop support for Java JDK 17
 - CHANGE: Add support for Java JDK 23
 
 ## 1.0.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ cd dnsimple-java
 
 - Eclipse Temurin JDK 21.0.5+11-:TS
 
-    From [https://www.oracle.com/java/technologies/downloads/](https://www.oracle.com/java/technologies/downloads/)
+    From [https://adoptium.net/es/temurin/releases/](https://adoptium.net/es/temurin/releases/)
 
 ### 3. Build and test
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,9 +13,9 @@ cd dnsimple-java
 
 ### 2. Install external tools
 
-The project includes an [ASDF](https://github.com/asdf-vm/asdf) `.tool-versions` file to set up the JVM required to work on the project.
+- Oracle JDK
 
-You can install the required version of Java executing `asdf install` at the project's root directory.
+    From [https://www.oracle.com/java/technologies/downloads/](https://www.oracle.com/java/technologies/downloads/)
 
 ### 3. Build and test
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ cd dnsimple-java
 
 ### 2. Install external tools
 
-- Oracle JDK
+- Eclipse Temurin JDK 21.0.5+11-:TS
 
     From [https://www.oracle.com/java/technologies/downloads/](https://www.oracle.com/java/technologies/downloads/)
 

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016-2022 DNSimple Corporation
+Copyright (c) 2016-2024 DNSimple Corporation
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -122,4 +122,4 @@ When developing unit tests for your application, you should stub responses from 
 
 ## License
 
-Copyright (c) 2016-2022 DNSimple Corporation. This is Free Software distributed under the MIT license.
+Copyright (c) 2016-2024 DNSimple Corporation. This is Free Software distributed under the MIT license.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A Java client for the [DNSimple API v2](https://developer.dnsimple.com/v2/).
 
 ## Requirements
 
-This library is tested with Java 17 (Temurin 21) and built for Java 17 JVMs.
+This library is tested with Java 21+ (Temurin 21) and built for Java 21+ JVMs.
 
 You must also have an activated DNSimple account to access the DNSimple API.
 

--- a/src/main/java/com/dnsimple/endpoints/Domains.java
+++ b/src/main/java/com/dnsimple/endpoints/Domains.java
@@ -94,7 +94,9 @@ public class Domains {
      * @param domain  The domain ID or name
      * @return The list collaborators response
      * @see <a href="https://developer.dnsimple.com/v2/domains/collaborators/#list">https://developer.dnsimple.com/v2/domains/collaborators/#list</a>
+     * @deprecated `DomainCollaborators` have been deprecated and will be removed in the next major version. Please use our Domain Access Control feature.
      */
+    @Deprecated(since = "2.0.0", forRemoval = true)
     public PaginatedResponse<Collaborator> listCollaborators(Number account, String domain) {
         return client.page(GET, account + "/domains/" + domain + "/collaborators", ListOptions.empty(), null, Collaborator.class);
     }
@@ -107,7 +109,9 @@ public class Domains {
      * @param options The options for the list request
      * @return The list collaborators response
      * @see <a href="https://developer.dnsimple.com/v2/domains/collaborators/#listCollaborators">https://developer.dnsimple.com/v2/domains/collaborators/#listCollaborators</a>
+     * @deprecated `DomainCollaborators` have been deprecated and will be removed in the next major version. Please use our Domain Access Control feature.
      */
+    @Deprecated(since = "2.0.0", forRemoval = true)
     public PaginatedResponse<Collaborator> listCollaborators(Number account, String domain, ListOptions options) {
         return client.page(GET, account + "/domains/" + domain + "/collaborators", options, null, Collaborator.class);
     }
@@ -120,7 +124,9 @@ public class Domains {
      * @param email   The email of the collaborator
      * @return The add collaborator response
      * @see <a href="https://developer.dnsimple.com/v2/domains/collaborators/#addCollaborator">https://developer.dnsimple.com/v2/domains/collaborators/#addCollaborator</a>
+     * @deprecated `DomainCollaborators` have been deprecated and will be removed in the next major version. Please use our Domain Access Control feature.
      */
+    @Deprecated(since = "2.0.0", forRemoval = true)
     public SimpleResponse<Collaborator> addCollaborator(Number account, String domain, String email) {
         return client.simple(POST, account + "/domains/" + domain + "/collaborators", ListOptions.empty(), singletonMap("email", email), Collaborator.class);
     }
@@ -133,7 +139,9 @@ public class Domains {
      * @param collaboratorId The collaborator ID
      * @return The remove collaborator response
      * @see <a href="https://developer.dnsimple.com/v2/domains/collaborators/#removeCollaborator">https://developer.dnsimple.com/v2/domains/collaborators/#removeCollaborator</a>
+     * @deprecated `DomainCollaborators` have been deprecated and will be removed in the next major version. Please use our Domain Access Control feature.
      */
+    @Deprecated(since = "2.0.0", forRemoval = true)
     public EmptyResponse removeCollaborator(Number account, String domain, String collaboratorId) {
         return client.empty(DELETE, account + "/domains/" + domain + "/collaborators/" + collaboratorId, ListOptions.empty(), null);
     }


### PR DESCRIPTION
The changes to go out in the next version (2.0.0) are:

- NEW: Added `alias_email` and `destination_email` to `EmailForward`
- CHANGED: Deprecated `from` and `to` fields in `EmailForward`
- CHANGE: Drop support for Java JDK 17
- CHANGE: Add support for Java JDK 23
- CHANGE: `DomainCollaborators` have been deprecated and will be removed in the next major version. Please use our Domain Access Control feature.

Belongs to https://github.com/dnsimple/dnsimple-engineering/issues/231
