### PR TITLE
Support the active attribute in EmailForward

### DIFF
--- a/src/main/java/com/dnsimple/data/EmailForward.java
+++ b/src/main/java/com/dnsimple/data/EmailForward.java
@@ -7,14 +7,16 @@ public class EmailForward {
     private final Long domainId;
     private final String aliasEmail;
     private final String destinationEmail;
+    private final Boolean active;
     private final OffsetDateTime createdAt;
     private final OffsetDateTime updatedAt;
 
-    public EmailForward(Long id, Long domainId, String aliasEmail, String destinationEmail, OffsetDateTime createdAt, OffsetDateTime updatedAt) {
+    public EmailForward(Long id, Long domainId, String aliasEmail, String destinationEmail, Boolean active, OffsetDateTime createdAt, OffsetDateTime updatedAt) {
         this.id = id;
         this.domainId = domainId;
         this.aliasEmail = aliasEmail;
         this.destinationEmail = destinationEmail;
+        this.active = active;
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;
     }
@@ -49,6 +51,10 @@ public class EmailForward {
 
     public String getDestinationEmail() {
         return destinationEmail;
+    }
+
+    public Boolean isActive() {
+        return active;
     }
 
     public OffsetDateTime getCreatedAt() {

--- a/src/test/java/com/dnsimple/endpoints/DomainEmailForwardsTest.java
+++ b/src/test/java/com/dnsimple/endpoints/DomainEmailForwardsTest.java
@@ -45,6 +45,7 @@ public class DomainEmailForwardsTest extends DnsimpleTestBase {
         PaginatedResponse<EmailForward> response = client.domains.listEmailForwards(1, "example.com");
         assertThat(response.getData(), hasSize(1));
         assertThat(response.getData().get(0).getId(), is(24809L));
+        assertThat(response.getData().get(0).isActive(), is(true));
     }
 
     @Test
@@ -64,6 +65,7 @@ public class DomainEmailForwardsTest extends DnsimpleTestBase {
         assertThat(emailForward.getFrom(), is("example@dnsimple.xyz"));
         assertThat(emailForward.getAliasEmail(), is("example@dnsimple.xyz"));
         assertThat(emailForward.getDestinationEmail(), is("example@example.com"));
+        assertThat(emailForward.isActive(), is(true));
         assertThat(emailForward.getCreatedAt(), is(OffsetDateTime.of(2021, 1, 25, 13, 54, 40, 0, UTC)));
         assertThat(emailForward.getUpdatedAt(), is(OffsetDateTime.of(2021, 1, 25, 13, 54, 40, 0, UTC)));
     }
@@ -91,6 +93,7 @@ public class DomainEmailForwardsTest extends DnsimpleTestBase {
                 hasEntry("destination_email", "example@example.com")
         ));
         assertThat(response.getData().getId(), is(41872L));
+        assertThat(response.getData().isActive(), is(true));
     }
 
     @Test


### PR DESCRIPTION
Support the `active` attribute in EmailForward

Belongs to https://github.com/dnsimple/dnsimple-engineering/issues/235