### PR TITLE
Fix error in Update Gradle Wrapper workflow

### DIFF
--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -2,10 +2,13 @@ plugins {
     id 'java'
 }
 
-group 'com.dnsimple'
-version '0.0.0'
-sourceCompatibility = '1.11'
-targetCompatibility = '1.11'
+group = 'com.dnsimple'
+version = '0.0.0'
+
+java {
+    sourceCompatibility = '1.17'
+    targetCompatibility = '1.17'
+}
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
Fixes the Update Gradle Workflow which has been failing for a while due to an incompatibility between our configuration and Gradle 9

<img width="2400" height="1243" alt="Screenshot 2025-08-18 at 12 31 36 PM" src="https://github.com/user-attachments/assets/01909666-fb4b-41c2-a6ec-2bf7247613f4" />

See example run: https://github.com/dnsimple/dnsimple-java/actions/runs/17027802204/job/48265510596

Belongs to https://github.com/dnsimple/dnsimple-engineering/issues/349

## Pre/Post Tasks

- [x] POST: Check if the Update Gradle Workflow succeeds