### PR TITLE
Replace wait-on-check-action with workflow_run

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,20 +5,19 @@ on:
   push:
     tags:
       - v*.*.*
+  workflow_run:
+    workflows:
+      - "CI"
+    types:
+      - completed
+    branches:
+      - main
 
 jobs:
   publish:
     name: Publish Client
     runs-on: ubuntu-latest
     steps:
-      - name: Wait for tests to succeed
-        uses: lewagon/wait-on-check-action@v1.4.0
-        with:
-          ref: 'refs/heads/main'
-          running-workflow-name: 'Publish Client'
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          wait-interval: 10
-          allowed-conclusions: success
       - name: Checkout Code
         uses: actions/checkout@v5
       - name: Set up JVM


### PR DESCRIPTION
Replaces the wait-on-check-action in the release workflow with `workflow_run`

Addresses https://github.com/dnsimple/dnsimple-java/issues/201
Belongs to https://github.com/dnsimple/dnsimple-engineering/issues/349