### PR TITLE
Remove from and to from EmailForwards

### DIFF
--- a/src/main/java/com/dnsimple/data/EmailForward.java
+++ b/src/main/java/com/dnsimple/data/EmailForward.java
@@ -29,22 +29,6 @@ public class EmailForward {
         return domainId;
     }
 
-    /**
-     * @deprecated use {@link #getAliasEmail()} instead
-     */
-    @Deprecated(since = "1.1.0", forRemoval = true)
-    public String getFrom() {
-        return aliasEmail;
-    }
-
-    /**
-     * @deprecated use {@link #getDestinationEmail} instead
-     */
-    @Deprecated(since = "1.1.0", forRemoval = true)
-    public String getTo() {
-        return destinationEmail;
-    }
-
     public String getAliasEmail() {
         return aliasEmail;
     }

--- a/src/test/java/com/dnsimple/endpoints/DomainEmailForwardsTest.java
+++ b/src/test/java/com/dnsimple/endpoints/DomainEmailForwardsTest.java
@@ -61,8 +61,6 @@ public class DomainEmailForwardsTest extends DnsimpleTestBase {
         EmailForward emailForward = client.domains.getEmailForward(1, "example.com", 41872).getData();
         assertThat(emailForward.getId(), is(41872L));
         assertThat(emailForward.getDomainId(), is(235146L));
-        assertThat(emailForward.getTo(), is("example@example.com"));
-        assertThat(emailForward.getFrom(), is("example@dnsimple.xyz"));
         assertThat(emailForward.getAliasEmail(), is("example@dnsimple.xyz"));
         assertThat(emailForward.getDestinationEmail(), is("example@example.com"));
         assertThat(emailForward.isActive(), is(true));


### PR DESCRIPTION
Belongs to https://github.com/dnsimple/dnsimple-app/issues/17733.

## Description
This PR removes the deprecated `from` and `to` models from the `EmailForward` model.