### PR TITLE
Dispatch release workflow from CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches:
       - main
+      - update-release-workflow
+    tags:
+      - v*.*.*
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-      - update-release-workflow
     tags:
       - v*.*.*
   pull_request:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,5 @@
 ---
-name: Release
+name: Release (Test)
 
 on:
   workflow_run:
@@ -15,7 +15,7 @@ jobs:
   publish:
     name: Publish Client
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' && github.ref_type == 'tag' }}
+    # if: ${{ github.event.workflow_run.conclusion == 'success' && github.ref_type == 'tag' }}
     steps:
       - name: Validate tag
         run: |
@@ -24,9 +24,8 @@ jobs:
             echo "Tag $TAG_NAME is valid"
           else
             echo "Tag $TAG_NAME is invalid"
-            # exit 1
+            exit 1
           fi
-          exit 1
       - name: Checkout Code
         uses: actions/checkout@v5
       - name: Set up JVM
@@ -36,11 +35,3 @@ jobs:
           java-version: '17'
       - name: Validate Gradle Wrapper
         uses: gradle/wrapper-validation-action@v3
-      - name: Publish Package
-        run: gradle clean build signMavenJavaPublication publishToSonatype closeAndReleaseSonatypeStagingRepository
-        env:
-          ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.JAR_SIGNING_KEY_ID }}
-          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.JAR_SIGNING_KEY }}
-          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.JAR_SIGNING_SIGNING_PASSWORD }}
-          ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.SONATYPE_CENTRAL_USER_TOKEN_USERNAME }}
-          ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.SONATYPE_CENTRAL_USER_TOKEN_PASSWORD }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push' && startsWith(github.event.workflow_run.head_branch, 'v') }}
     steps:
       - name: Check out the repository including tags
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,5 @@
 ---
-name: Release (Test)
+name: Release
 
 on:
   workflow_run:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,15 +51,6 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ needs.validate-tag.outputs.valid_tag == 'true' && github.event.workflow_run.conclusion == 'success' }}
     steps:
-      - name: Validate tag
-        run: |
-          TAG_NAME=${{ github.ref_name }}
-          if [[ $TAG_NAME =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "Tag $TAG_NAME is valid"
-          else
-            echo "Tag $TAG_NAME is invalid"
-            exit 1
-          fi
       - name: Checkout Code
         uses: actions/checkout@v5
       - name: Set up JVM

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,15 +7,49 @@ on:
       - "CI"
     types:
       - completed
-    branches:
-      - main
-      - update-release-workflow
 
 jobs:
+  validate-tag:
+    name: Check tag
+    runs-on: ubuntu-latest
+    outputs:
+      valid_tag: ${{ steps.validation.outputs.valid_tag }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push' && startsWith(github.event.workflow_run.head_branch, 'v') }}
+    steps:
+      - name: Check out the repository including tags
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+          fetch-depth: 0
+          fetch-tags: true
+      - name: Validate tag
+        id: validation
+        run: |
+          # Validation is necessary in the unlikely case that a branch matching the tag naming pattern is pushed
+          # and the CI workflow in that branch is modified to run upon a push to that branch
+          REF='${{ github.event.workflow_run.head_branch }}' # This can be a branch or tag name
+          if [[ "$REF" != v*.*.* ]]; then
+            echo "valid_tag=false" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          # Validate that the tag exists
+          if ! git rev-parse -q --verify "refs/tags/$REF" >/dev/null; then
+            echo "There is no tag matching $REF - $REF is a branch"
+            echo "valid_tag=false" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          # Validate that the tag is for the same commit that was pushed
+          TAG_SHA="$(git rev-parse "$REF^{commit}")"
+          COMMIT_SHA="${{ github.event.workflow_run.head_sha }}"
+          if [ "$TAG_SHA" != "$COMMIT_SHA" ]; then
+            echo "Tag SHA $TAG_SHA does not match pushed commit SHA $COMMIT_SHA"
+            echo "valid_tag=false" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          echo "Tag $REF exists and is valid. Tag $TAG_SHA matches the pushed commit $COMMIT_SHA."
+          echo "valid_tag=true"  >> "$GITHUB_OUTPUT"
   publish:
     name: Publish Client
+    needs: validate-tag
     runs-on: ubuntu-latest
-    # if: ${{ github.event.workflow_run.conclusion == 'success' && github.ref_type == 'tag' }}
+    if: ${{ needs.validate-tag.outputs.valid_tag == 'true' && github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Validate tag
         run: |
@@ -35,3 +69,11 @@ jobs:
           java-version: '17'
       - name: Validate Gradle Wrapper
         uses: gradle/wrapper-validation-action@v3
+      - name: Publish Package
+        run: gradle clean build signMavenJavaPublication publishToSonatype closeAndReleaseSonatypeStagingRepository
+        env:
+          ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.JAR_SIGNING_KEY_ID }}
+          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.JAR_SIGNING_KEY }}
+          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.JAR_SIGNING_SIGNING_PASSWORD }}
+          ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.SONATYPE_CENTRAL_USER_TOKEN_USERNAME }}
+          ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.SONATYPE_CENTRAL_USER_TOKEN_PASSWORD }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,23 +2,31 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - v*.*.*
+  workflow_run:
+    workflows:
+      - "CI"
+    types:
+      - completed
+    branches:
+      - main
+      - update-release-workflow
 
 jobs:
   publish:
     name: Publish Client
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.ref_type == 'tag' }}
     steps:
-      - name: Wait for tests to succeed
-        uses: lewagon/wait-on-check-action@v1.4.0
-        with:
-          ref: 'refs/heads/main'
-          running-workflow-name: 'Publish Client'
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          wait-interval: 10
-          allowed-conclusions: success
+      - name: Validate tag
+        run: |
+          TAG_NAME=${{ github.ref_name }}
+          if [[ $TAG_NAME =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Tag $TAG_NAME is valid"
+          else
+            echo "Tag $TAG_NAME is invalid"
+            # exit 1
+          fi
+          exit 1
       - name: Checkout Code
         uses: actions/checkout@v5
       - name: Set up JVM


### PR DESCRIPTION
This updates our workflows to dispatch `Release` from the `CI` workflow.

Currently the `Release` workflow is directly triggered upon a tag push but as discussed [here](https://github.com/dnsimple/dnsimple-java/issues/201#issuecomment-3199800867), it relies on a third-party action to validate that the CI workflow ran successfully for the tagged commit.

With the changes in this PR, we will use `workflow_run` to make the `Release` workflow run automatically when the `CI` workflow completes, with the following necessary accompanying changes:
- Trigger the `CI` workflow upon a tag push that matches a valid pattern
- We introduce a `validate-tag` job to the `Release` workflow, that validates that the `CI` workflow was triggered from a push of a valid tag, and only allows the `publish` job to run if the validation succeeds. This is necessary because the `CI` workflow can be triggered by other conditions including a push to `main` branch.

Addresses https://github.com/dnsimple/dnsimple-java/issues/201

Note: Here is a simplified version of the workflows for ease of testing in any repository: https://gist.github.com/lokst/e8ee94f6289bbc82a25b21c96e44bf2f