### PR TITLE
Add domain push identifier support and account name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 This project uses [Semantic Versioning 2.0.0](http://semver.org/), the format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## Unreleased
+
+### Added
+
+- Added `initiatePushWithIdentifier` to initiate domain pushes using an account identifier.
+- Added `getName` to `Account`.
+
+### Deprecated
+
+- Deprecated `initiatePush`. Use `initiatePushWithIdentifier` instead.
+
 ## 5.2.0 - 2026-03-23
 
 ### Added

--- a/src/main/java/com/dnsimple/data/Account.java
+++ b/src/main/java/com/dnsimple/data/Account.java
@@ -5,13 +5,15 @@ import java.time.OffsetDateTime;
 public class Account {
     private final Long id;
     private final String email;
+    private final String name;
     private final String planIdentifier;
     private final OffsetDateTime createdAt;
     private final OffsetDateTime updatedAt;
 
-    public Account(Long id, String email, String planIdentifier, OffsetDateTime createdAt, OffsetDateTime updatedAt) {
+    public Account(Long id, String email, String name, String planIdentifier, OffsetDateTime createdAt, OffsetDateTime updatedAt) {
         this.id = id;
         this.email = email;
+        this.name = name;
         this.planIdentifier = planIdentifier;
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;
@@ -23,6 +25,10 @@ public class Account {
 
     public String getEmail() {
         return email;
+    }
+
+    public String getName() {
+        return name;
     }
 
     public String getPlanIdentifier() {

--- a/src/main/java/com/dnsimple/endpoints/Domains.java
+++ b/src/main/java/com/dnsimple/endpoints/Domains.java
@@ -266,16 +266,16 @@ public class Domains {
     }
 
     /**
-     * Initiate a push using a domain push identifier.
+     * Initiate a push using an account identifier.
      *
      * @param account                  The account ID
      * @param domain                   The domain name or ID
-     * @param newDomainPushIdentifier  The domain push identifier of the target account
+     * @param newAccountIdentifier     The account identifier of the target account
      * @return The initiate push response
      * @see <a href="https://developer.dnsimple.com/v2/domains/pushes/#initiateDomainPush">https://developer.dnsimple.com/v2/domains/pushes/#initiateDomainPush</a>
      */
-    public SimpleResponse<DomainPush> initiatePushWithIdentifier(Number account, String domain, String newDomainPushIdentifier) {
-        return client.simple(POST, account + "/domains/" + domain + "/pushes", ListOptions.empty(), singletonMap("new_domain_push_identifier", newDomainPushIdentifier), DomainPush.class);
+    public SimpleResponse<DomainPush> initiatePushWithIdentifier(Number account, String domain, String newAccountIdentifier) {
+        return client.simple(POST, account + "/domains/" + domain + "/pushes", ListOptions.empty(), singletonMap("new_account_identifier", newAccountIdentifier), DomainPush.class);
     }
 
     /**

--- a/src/main/java/com/dnsimple/endpoints/Domains.java
+++ b/src/main/java/com/dnsimple/endpoints/Domains.java
@@ -266,14 +266,29 @@ public class Domains {
     }
 
     /**
+     * Initiate a push using a domain push identifier.
+     *
+     * @param account                  The account ID
+     * @param domain                   The domain name or ID
+     * @param newDomainPushIdentifier  The domain push identifier of the target account
+     * @return The initiate push response
+     * @see <a href="https://developer.dnsimple.com/v2/domains/pushes/#initiateDomainPush">https://developer.dnsimple.com/v2/domains/pushes/#initiateDomainPush</a>
+     */
+    public SimpleResponse<DomainPush> initiatePushWithIdentifier(Number account, String domain, String newDomainPushIdentifier) {
+        return client.simple(POST, account + "/domains/" + domain + "/pushes", ListOptions.empty(), singletonMap("new_domain_push_identifier", newDomainPushIdentifier), DomainPush.class);
+    }
+
+    /**
      * Initiate a push.
      *
      * @param account         The account ID
      * @param domain          The domain name or ID
      * @param newAccountEmail The email address of the target DNSimple account
      * @return The initiate push response
+     * @deprecated Use {@link #initiatePushWithIdentifier(Number, String, String)} instead
      * @see <a href="https://developer.dnsimple.com/v2/domains/pushes/#initiateDomainPush">https://developer.dnsimple.com/v2/domains/pushes/#initiateDomainPush</a>
      */
+    @Deprecated
     public SimpleResponse<DomainPush> initiatePush(Number account, String domain, String newAccountEmail) {
         return client.simple(POST, account + "/domains/" + domain + "/pushes", ListOptions.empty(), singletonMap("new_account_email", newAccountEmail), DomainPush.class);
     }

--- a/src/test/java/com/dnsimple/endpoints/AccountsTest.java
+++ b/src/test/java/com/dnsimple/endpoints/AccountsTest.java
@@ -25,6 +25,7 @@ public class AccountsTest extends DnsimpleTestBase {
         assertThat(accounts, hasSize(1));
         assertThat(accounts.get(0).getId(), is(123L));
         assertThat(accounts.get(0).getEmail(), is("john@example.com"));
+        assertThat(accounts.get(0).getName(), is("John"));
         assertThat(accounts.get(0).getPlanIdentifier(), is("dnsimple-personal"));
         assertThat(accounts.get(0).getCreatedAt(), is(OffsetDateTime.of(2011, 9, 11, 17, 15, 58, 0, UTC)));
         assertThat(accounts.get(0).getUpdatedAt(), is(OffsetDateTime.of(2016, 6, 3, 15, 2, 26, 0, UTC)));

--- a/src/test/java/com/dnsimple/endpoints/DomainPushesTest.java
+++ b/src/test/java/com/dnsimple/endpoints/DomainPushesTest.java
@@ -28,6 +28,14 @@ public class DomainPushesTest extends DnsimpleTestBase {
     }
 
     @Test
+    public void testInitiatePushWithIdentifierProducesPush() {
+        server.stubFixtureAt("initiatePush/success.http");
+        DomainPush domainPush = client.domains.initiatePushWithIdentifier(1, "example.com", "abc123").getData();
+        assertThat(domainPush.getId(), is(1L));
+        assertThat(domainPush.getAccountId(), is(2020L));
+    }
+
+    @Test
     public void testListPushesProducesPushList() {
         server.stubFixtureAt("listPushes/success.http");
         List<DomainPush> domainPushes = client.domains.listPushes(1).getData();

--- a/src/test/resources/com/dnsimple/accounts/success-account.http
+++ b/src/test/resources/com/dnsimple/accounts/success-account.http
@@ -17,4 +17,4 @@ x-permitted-cross-domain-policies: none
 x-xss-protection: 1; mode=block
 strict-transport-security: max-age=31536000
 
-{"data":[{"id":123,"email":"john@example.com","plan_identifier":"dnsimple-personal","created_at":"2011-09-11T17:15:58Z","updated_at":"2016-06-03T15:02:26Z"}]}
+{"data":[{"id":123,"email":"john@example.com","name":"John","plan_identifier":"dnsimple-personal","created_at":"2011-09-11T17:15:58Z","updated_at":"2016-06-03T15:02:26Z"}]}

--- a/src/test/resources/com/dnsimple/accounts/success-user.http
+++ b/src/test/resources/com/dnsimple/accounts/success-user.http
@@ -17,5 +17,5 @@ x-permitted-cross-domain-policies: none
 x-xss-protection: 1; mode=block
 strict-transport-security: max-age=31536000
 
-{"data":[{"id":123,"email":"john@example.com","plan_identifier":"dnsimple-personal","created_at":"2011-09-11T17:15:58Z","updated_at":"2016-06-03T15:02:26Z"},{"id":456,"email":"ops@company.com","plan_identifier":"teams-v1-monthly","created_at":"2012-03-16T16:02:54Z","updated_at":"2016-06-14T11:23:16Z"}]}
+{"data":[{"id":123,"email":"john@example.com","name":"John","plan_identifier":"dnsimple-personal","created_at":"2011-09-11T17:15:58Z","updated_at":"2016-06-03T15:02:26Z"},{"id":456,"email":"ops@company.com","name":"Ops Company","plan_identifier":"teams-v1-monthly","created_at":"2012-03-16T16:02:54Z","updated_at":"2016-06-14T11:23:16Z"}]}
 

--- a/src/test/resources/com/dnsimple/listAccounts/success-account.http
+++ b/src/test/resources/com/dnsimple/listAccounts/success-account.http
@@ -17,4 +17,4 @@ x-permitted-cross-domain-policies: none
 x-xss-protection: 1; mode=block
 strict-transport-security: max-age=31536000
 
-{"data":[{"id":123,"email":"john@example.com","plan_identifier":"dnsimple-personal","created_at":"2011-09-11T17:15:58Z","updated_at":"2016-06-03T15:02:26Z"}]}
+{"data":[{"id":123,"email":"john@example.com","name":"John","plan_identifier":"dnsimple-personal","created_at":"2011-09-11T17:15:58Z","updated_at":"2016-06-03T15:02:26Z"}]}

--- a/src/test/resources/com/dnsimple/listAccounts/success-user.http
+++ b/src/test/resources/com/dnsimple/listAccounts/success-user.http
@@ -17,4 +17,4 @@ x-permitted-cross-domain-policies: none
 x-xss-protection: 1; mode=block
 strict-transport-security: max-age=31536000
 
-{"data":[{"id":123,"email":"john@example.com","plan_identifier":"dnsimple-personal","created_at":"2011-09-11T17:15:58Z","updated_at":"2016-06-03T15:02:26Z"},{"id":456,"email":"ops@company.com","plan_identifier":"teams-v1-monthly","created_at":"2012-03-16T16:02:54Z","updated_at":"2016-06-14T11:23:16Z"}]}
+{"data":[{"id":123,"email":"john@example.com","name":"John","plan_identifier":"dnsimple-personal","created_at":"2011-09-11T17:15:58Z","updated_at":"2016-06-03T15:02:26Z"},{"id":456,"email":"ops@company.com","name":"Ops Company","plan_identifier":"teams-v1-monthly","created_at":"2012-03-16T16:02:54Z","updated_at":"2016-06-14T11:23:16Z"}]}

--- a/src/test/resources/com/dnsimple/whoami/success-account.http
+++ b/src/test/resources/com/dnsimple/whoami/success-account.http
@@ -12,4 +12,4 @@ x-request-id: 15a7f3a5-7ee5-4e36-ac5a-8c21c2e1fffd
 x-runtime: 0.141588
 strict-transport-security: max-age=31536000
 
-{"data":{"user":null,"account":{"id":1,"email":"example-account@example.com","plan_identifier":"teams-v1-monthly","created_at":"2015-09-18T23:04:37Z","updated_at":"2016-06-09T20:03:39Z"}}}
+{"data":{"user":null,"account":{"id":1,"email":"example-account@example.com","name":"Example Account","plan_identifier":"teams-v1-monthly","created_at":"2015-09-18T23:04:37Z","updated_at":"2016-06-09T20:03:39Z"}}}

--- a/src/test/resources/com/dnsimple/whoami/success.http
+++ b/src/test/resources/com/dnsimple/whoami/success.http
@@ -12,4 +12,4 @@ x-request-id: 15a7f3a5-7ee5-4e36-ac5a-8c21c2e1fffd
 x-runtime: 0.141588
 strict-transport-security: max-age=31536000
 
-{"data":{"user":null,"account":{"id":1,"email":"example-account@example.com","plan_identifier":"teams-v1-monthly","created_at":"2015-09-18T23:04:37Z","updated_at":"2016-06-09T20:03:39Z"}}}
+{"data":{"user":null,"account":{"id":1,"email":"example-account@example.com","name":"Example Account","plan_identifier":"teams-v1-monthly","created_at":"2015-09-18T23:04:37Z","updated_at":"2016-06-09T20:03:39Z"}}}


### PR DESCRIPTION
## Summary
- Add `initiatePushWithIdentifier` method for domain pushes
- Deprecate `initiatePush` with email in favor of push identifier
- Add `name` field to `Account`
- Update fixtures and tests

Closes dnsimple/dnsimple-engineering#425