### PR TITLE
Support trustee service in transfers

### DIFF
--- a/src/main/java/com/dnsimple/data/DomainTransfer.java
+++ b/src/main/java/com/dnsimple/data/DomainTransfer.java
@@ -7,17 +7,19 @@ public class DomainTransfer {
     private final String state;
     private final boolean autoRenew;
     private final boolean whoisPrivacy;
+    private final boolean trusteeService;
     private final String statusDescription;
     private final String createdAt;
     private final String updatedAt;
 
-    public DomainTransfer(Integer id, Integer domainId, Integer registrantId, String state, boolean autoRenew, boolean whoisPrivacy, String statusDescription, String createdAt, String updatedAt) {
+    public DomainTransfer(Integer id, Integer domainId, Integer registrantId, String state, boolean autoRenew, boolean whoisPrivacy, boolean trusteeService, String statusDescription, String createdAt, String updatedAt) {
         this.id = id;
         this.domainId = domainId;
         this.registrantId = registrantId;
         this.state = state;
         this.autoRenew = autoRenew;
         this.whoisPrivacy = whoisPrivacy;
+        this.trusteeService = trusteeService;
         this.statusDescription = statusDescription;
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;
@@ -45,6 +47,10 @@ public class DomainTransfer {
 
     public boolean hasWhoisPrivacy() {
         return whoisPrivacy;
+    }
+
+    public boolean hasTrusteeService() {
+        return trusteeService;
     }
 
     public String getStatusDescription() {

--- a/src/main/java/com/dnsimple/request/TransferOptions.java
+++ b/src/main/java/com/dnsimple/request/TransferOptions.java
@@ -12,42 +12,44 @@ public class TransferOptions {
     private final Boolean autoRenew;
     private final Map<String, String> extendedAttributes;
     private final String premiumPrice;
+    private final Boolean trusteeService;
 
-    private TransferOptions(Long registrantId, String authCode, Boolean whoisPrivacy, Boolean autoRenew, Map<String, String> extendedAttributes, String premiumPrice) {
+    private TransferOptions(Long registrantId, String authCode, Boolean whoisPrivacy, Boolean autoRenew, Map<String, String> extendedAttributes, String premiumPrice, Boolean trusteeService) {
         this.registrantId = registrantId;
         this.authCode = authCode;
         this.whoisPrivacy = whoisPrivacy;
         this.autoRenew = autoRenew;
         this.extendedAttributes = extendedAttributes;
         this.premiumPrice = premiumPrice;
+        this.trusteeService = trusteeService;
     }
 
     /**
      * @param registrantId The ID of an existing contact in your account.
      */
     public static TransferOptions of(Number registrantId) {
-        return new TransferOptions(registrantId.longValue(), null, false, true, emptyMap(), null);
+        return new TransferOptions(registrantId.longValue(), null, false, true, emptyMap(), null, null);
     }
 
     /**
      * Set the authCode required for TLDS that require authorization-based transfer (the vast majority of TLDs).
      */
     public TransferOptions authCode(String authCode) {
-        return new TransferOptions(registrantId, authCode, whoisPrivacy, autoRenew, extendedAttributes, premiumPrice);
+        return new TransferOptions(registrantId, authCode, whoisPrivacy, autoRenew, extendedAttributes, premiumPrice, trusteeService);
     }
 
     /**
      * Enable the whois privacy as part of the transfer. An extra cost may apply.
      */
     public TransferOptions whoisPrivacy() {
-        return new TransferOptions(registrantId, authCode, true, autoRenew, extendedAttributes, premiumPrice);
+        return new TransferOptions(registrantId, authCode, true, autoRenew, extendedAttributes, premiumPrice, trusteeService);
     }
 
     /**
      * Disable the auto-renewal of the domain.
      */
     public TransferOptions noAutoRenew() {
-        return new TransferOptions(registrantId, authCode, whoisPrivacy, false, extendedAttributes, premiumPrice);
+        return new TransferOptions(registrantId, authCode, whoisPrivacy, false, extendedAttributes, premiumPrice, trusteeService);
     }
 
     /**
@@ -57,13 +59,23 @@ public class TransferOptions {
     public TransferOptions extendedAttribute(String name, String value) {
         Map<String, String> newExtendedAttributes = new HashMap<>(extendedAttributes);
         newExtendedAttributes.put(name, value);
-        return new TransferOptions(registrantId, authCode, whoisPrivacy, autoRenew, newExtendedAttributes, premiumPrice);
+        return new TransferOptions(registrantId, authCode, whoisPrivacy, autoRenew, newExtendedAttributes, premiumPrice, trusteeService);
     }
 
     /**
      * Required as confirmation of the price, only if the domain is premium.
      */
     public TransferOptions premiumPrice(String premiumPrice) {
-        return new TransferOptions(registrantId, authCode, whoisPrivacy, autoRenew, extendedAttributes, premiumPrice);
+        return new TransferOptions(registrantId, authCode, whoisPrivacy, autoRenew, extendedAttributes, premiumPrice, trusteeService);
+    }
+
+    /**
+     * Enable trustee service as part of the domain transfer.
+     *
+     * <p>This parameter is optional; if you never call this method, the SDK will omit
+     * {@code trustee_service} from the JSON request payload.</p>
+     */
+    public TransferOptions trusteeService() {
+        return new TransferOptions(registrantId, authCode, whoisPrivacy, autoRenew, extendedAttributes, premiumPrice, true);
     }
 }

--- a/src/test/java/com/dnsimple/endpoints/RegistrarTest.java
+++ b/src/test/java/com/dnsimple/endpoints/RegistrarTest.java
@@ -165,6 +165,7 @@ public class RegistrarTest extends DnsimpleTestBase {
         assertThat(transfer.getState(), is("cancelled"));
         assertThat(transfer.hasAutoRenew(), is(false));
         assertThat(transfer.hasWhoisPrivacy(), is(false));
+        assertThat(transfer.hasTrusteeService(), is(false));
         assertThat(transfer.getStatusDescription(), is("Canceled by customer"));
         assertThat(transfer.getCreatedAt(), is("2020-06-05T18:08:00Z"));
         assertThat(transfer.getUpdatedAt(), is("2020-06-05T18:10:01Z"));
@@ -183,6 +184,7 @@ public class RegistrarTest extends DnsimpleTestBase {
         assertThat(transfer.getState(), is("transferring"));
         assertThat(transfer.hasAutoRenew(), is(false));
         assertThat(transfer.hasWhoisPrivacy(), is(false));
+        assertThat(transfer.hasTrusteeService(), is(false));
         assertThat(transfer.getStatusDescription(), isEmptyOrNullString());
         assertThat(transfer.getCreatedAt(), is("2020-06-05T18:08:00Z"));
         assertThat(transfer.getUpdatedAt(), is("2020-06-05T18:08:04Z"));


### PR DESCRIPTION
Updated **src/main/java/com/dnsimple/data/DomainTransfer.java**
- Added `trusteeService` field to the `DomainTransfer` response class so the value is parsed from API responses

Updated **src/main/java/com/dnsimple/request/TransferOptions.java**
- Added `trusteeService()` builder method so callers can opt into the trustee service when initiating a transfer

Addresses https://github.com/dnsimple/dnsimple-app/issues/34689
Belongs to https://github.com/dnsimple/dnsimple-business/issues/2641

### QA

(Optional for reviewers)

From the console (adjust `accountId`, `registrantId`, `domainName` and `apiBase` accordingly) run `./gradlew runQA`

```java
package com.dnsimple;

import com.dnsimple.data.DomainTransfer;
import com.dnsimple.exception.BadRequestException;
import com.dnsimple.request.TransferOptions;
import com.dnsimple.response.SimpleResponse;

public final class qa_transfer_trustee {

    private qa_transfer_trustee() {
    }

    public static void main(String[] args) {
        String token = System.getenv("TOKEN");
        if (token == null || token.isEmpty()) {
            System.err.println("ERROR: TOKEN environment variable is required");
            System.exit(1);
        }

        long accountId = 2L;
        long registrantId = 27L;
        String domainName = "example.com";

        Client client = new Client.Builder()
                .apiBase("http://api.dnsimple.localhost:3000")
                .accessToken(token)
                .build();

        // Transfer a domain with trustee service enabled
        try {
            TransferOptions options = TransferOptions.of(registrantId)
                    .authCode("x1y2z3")
                    .trusteeService();
            SimpleResponse<DomainTransfer> response = client.registrar.transferDomain(accountId, domainName, options);
            DomainTransfer transfer = response.getData();
            System.out.printf("transfer domain_id=%s trustee_service=%s state=%s%n",
                    transfer.getDomainId(), transfer.hasTrusteeService(), transfer.getState());

            // Get the domain transfer to verify
            transfer = client.registrar.getDomainTransfer(accountId, domainName, transfer.getId()).getData();
            System.out.printf("get_transfer id=%s trustee_service=%s state=%s%n",
                    transfer.getId(), transfer.hasTrusteeService(), transfer.getState());
        } catch (BadRequestException e) {
            System.out.printf("(%d)%nReason: Bad Request%nHTTP response body: %s%n", e.getStatusCode(), e.getBody());
        }
    }
}
```

#### QA results

```
(400)
Reason: Bad Request
HTTP response body: {message=TLD .COM does not support trustee service}
```

```
(400)
Reason: Bad Request
HTTP response body: {message=Unable to complete transfer at the registrar. Invalid attribute value syntax [Parameter value syntax error; Invalid transfer authorisation code], errors={}}
```

### Deployment Pre/Post tasks

- [x] PRE: Wait till release is ready to be made
- [x] POST: Create a release version

### Deployment Verification

- [x] Verify release is created